### PR TITLE
Fixed 'code' tags stylings and added InlineCode component

### DIFF
--- a/components/common/Code/Code.tsx
+++ b/components/common/Code/Code.tsx
@@ -29,7 +29,7 @@ export default function Code({ code, children, language, img, lines }) {
     return () => {
       window.initial.prism = false;
     };
-  }, []);
+  }, [codeElement]);
 
   useEffect(() => {
     let customCode = code !== undefined ? code : children;

--- a/components/common/Code/InlineCode.module.css
+++ b/components/common/Code/InlineCode.module.css
@@ -1,0 +1,8 @@
+.Container {
+  color: #ff4b4b;
+  border: 1px solid var(--default-border-color);
+  border-radius: 4px;
+  background: transparent;
+  padding: 4px;
+  font-size: 14px;
+}

--- a/components/common/Code/InlineCode.tsx
+++ b/components/common/Code/InlineCode.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import styles from "./InlineCode.module.css";
+
+interface InlineCodeProps {
+  content: string;
+}
+
+function InlineCode({ content }: InlineCodeProps) {
+  return <code className={styles.Container}>{content}</code>;
+}
+
+export default InlineCode;

--- a/lib/markdoc.ts
+++ b/lib/markdoc.ts
@@ -19,6 +19,7 @@ import StepVisualInfo from "../components/Steps/Step/StepVisualInfo/StepVisualIn
 import ExtraContent from "../components/Steps/ExtraContent/ExtraContent";
 import Tile from "../components/common/Tiles/Tile/Tile";
 import TilesContainer from "../components/common/Tiles/TilesContainer/TilesContainer";
+import InlineCode from "../components/common/Code/InlineCode";
 
 import * as allTags from "../markdoc/tags";
 import * as allNodes from "../markdoc/nodes";
@@ -51,6 +52,7 @@ export const components = {
   ExtraContent,
   Tile,
   TilesContainer,
+  InlineCode,
 };
 
 export const configs: Config = {

--- a/markdoc/nodes/code.markdoc.ts
+++ b/markdoc/nodes/code.markdoc.ts
@@ -1,0 +1,6 @@
+export const code = {
+  render: "InlineCode",
+  attributes: {
+    content: { type: String },
+  },
+};

--- a/markdoc/nodes/index.ts
+++ b/markdoc/nodes/index.ts
@@ -1,3 +1,4 @@
 /* Use this file to export your markdoc nodes */
-export * from './fence.markdoc';
-export * from './heading.markdoc';
+export * from "./code.markdoc";
+export * from "./fence.markdoc";
+export * from "./heading.markdoc";


### PR DESCRIPTION
- [x] Fixed styling for code blocks where the keywords were not color coded
<img width="497" alt="Screenshot 2022-12-02 at 11 36 11 PM" src="https://user-images.githubusercontent.com/51777795/205357498-a09c0e01-2919-4fcf-b151-0023a3844ff8.png">

- [x] Added new InlineCode block to render for `code` node
<img width="348" alt="Screenshot 2022-12-02 at 11 36 23 PM" src="https://user-images.githubusercontent.com/51777795/205357510-eefab8e6-49a3-4c3a-aec1-79cdece6797c.png">
