### PR TITLE
ui: modified the tile tag to be able to pass children

### DIFF
--- a/components/common/Tiles/Tile/Tile.module.css
+++ b/components/common/Tiles/Tile/Tile.module.css
@@ -7,9 +7,10 @@
   border-radius: 4px;
   cursor: pointer;
   transition: box-shadow 0.2s ease-in-out;
+  color: rgb(78, 86, 109);
 }
 
-.Container:hover {
+.HoverEffect:hover {
   box-shadow: 0 0 0 1px rgba(50, 50, 93, 0.01),
     0 7px 14px 0 rgba(50, 50, 93, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.02);
 }
@@ -19,8 +20,10 @@
   font-weight: 500;
 }
 
-.Container {
-  color: rgb(78, 86, 109);
+.Container :nth-child(2) {
   margin-top: 8px;
-  font-weight: 400;
+}
+
+.Container > ul > li > * {
+  margin-top: 0px;
 }

--- a/components/common/Tiles/Tile/Tile.module.css
+++ b/components/common/Tiles/Tile/Tile.module.css
@@ -19,7 +19,7 @@
   font-weight: 500;
 }
 
-.Container span {
+.Container {
   color: rgb(78, 86, 109);
   margin-top: 8px;
   font-weight: 400;

--- a/components/common/Tiles/Tile/Tile.tsx
+++ b/components/common/Tiles/Tile/Tile.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useCallback } from "react";
 import { getUrlWithVersion } from "../../../../utils/CommonUtils";
 import styles from "./Tile.module.css";
+import classNames from "classnames";
 
 interface TileProps {
   description: string;
@@ -18,14 +19,29 @@ function Tile({
   isExternalLink = false,
   children,
 }: TileProps) {
-  return (
-    <Link href={isExternalLink ? link : getUrlWithVersion(link)}>
-      <div className={styles.Container}>
-        <h4>{title}</h4>
-        <span>{description}</span>
-        {children}
-      </div>
-    </Link>
+  const getWrappedTile = useCallback(
+    (tileContainer: ReactNode) =>
+      link ? (
+        <Link
+          target={isExternalLink ? "_blank" : "_self"}
+          href={isExternalLink ? link : getUrlWithVersion(link)}
+        >
+          {tileContainer}
+        </Link>
+      ) : (
+        tileContainer
+      ),
+    [link, isExternalLink]
+  );
+
+  return getWrappedTile(
+    <div
+      className={classNames(styles.Container, link ? styles.HoverEffect : "")}
+    >
+      <h4>{title}</h4>
+      {description && <span>{description}</span>}
+      {children}
+    </div>
   );
 }
 

--- a/components/common/Tiles/Tile/Tile.tsx
+++ b/components/common/Tiles/Tile/Tile.tsx
@@ -20,7 +20,7 @@ function Tile({
   children,
 }: TileProps) {
   const getWrappedTile = useCallback(
-    (tileContainer: ReactNode) =>
+    (tileContainer: JSX.Element): JSX.Element =>
       link ? (
         <Link
           target={isExternalLink ? "_blank" : "_self"}

--- a/components/common/Tiles/Tile/Tile.tsx
+++ b/components/common/Tiles/Tile/Tile.tsx
@@ -8,14 +8,22 @@ interface TileProps {
   link: string;
   title: string;
   isExternalLink?: boolean;
+  children?: ReactNode;
 }
 
-function Tile({ description, link, title, isExternalLink = false }: TileProps) {
+function Tile({
+  description,
+  link,
+  title,
+  isExternalLink = false,
+  children,
+}: TileProps) {
   return (
     <Link href={isExternalLink ? link : getUrlWithVersion(link)}>
       <div className={styles.Container}>
         <h4>{title}</h4>
         <span>{description}</span>
+        {children}
       </div>
     </Link>
   );


### PR DESCRIPTION
Previously only string could be passed as description content to the tile tags

fixes #68 

- [x] Added ability for the tiles tags to pass children to allow using other tags and nodes of Markdoc inside the tiles
<img width="370" alt="Screenshot 2023-04-21 at 4 57 22 PM" src="https://user-images.githubusercontent.com/51777795/233624886-882dbcf4-4a20-421f-aa1f-ea7d5616892e.png">
