### PR TITLE
ui: improvements for from #93

### DIFF
--- a/components/Search/Search.module.css
+++ b/components/Search/Search.module.css
@@ -41,6 +41,11 @@
   display: none;
 }
 
+.SearchModal ol {
+  list-style: none;
+  margin: 0px;
+}
+
 .VisibleModal {
   background-color: white;
   padding: 12px;

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -61,7 +61,7 @@ export default function Search() {
 
   const handleKey = (e: KeyboardEvent) => {
     e.stopPropagation();
-    if (searchValue) {
+    if (isSuggestionVisible) {
       const searchResults = document.querySelectorAll(".ais-Hits-item");
 
       switch (e.key) {

--- a/components/SideNav/SideNav.tsx
+++ b/components/SideNav/SideNav.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { forwardRef, useEffect } from "react";
 import { ReactComponent as OverviewIcon } from "../../images/icons/overview-icon.svg";
 import styles from "./SideNav.module.css";
 import ListItem from "./ListItem";
@@ -18,16 +18,16 @@ interface Props {
   sideNavCollapsed: boolean;
 }
 
-export default function SideNav({
-  sideNavCollapsed,
-  category,
-  items,
-  loading,
-  handleSetSideNavCollapsed,
-}: Props) {
-  // Ref to keep track if the side nav is collapsed before, when "code-preview-container" is in the view.
-  const autoCollapsed = useRef(false);
-
+export default forwardRef(function SideNav(
+  {
+    sideNavCollapsed,
+    category,
+    items,
+    loading,
+    handleSetSideNavCollapsed,
+  }: Props,
+  ref: React.MutableRefObject<boolean>
+) {
   const toggleSideNavCollapsed = () => {
     handleSetSideNavCollapsed(!sideNavCollapsed);
   };
@@ -35,7 +35,7 @@ export default function SideNav({
   useEffect(() => {
     const scrollEventListener = () => {
       // check if the SideNav was already collapsed before.
-      if (!autoCollapsed.current) {
+      if (ref && !ref.current) {
         const codePreviewComponent = document.getElementById(
           "code-preview-container"
         );
@@ -44,7 +44,12 @@ export default function SideNav({
 
           if (position?.top < window.innerHeight - 100) {
             handleSetSideNavCollapsed(true);
-            autoCollapsed.current = true;
+            // The hash element scrolling is dependent on this ref value ,
+            // to avoid the ongoing scrolling from stopping
+            // setting this timeout
+            setTimeout(() => {
+              ref.current = true;
+            }, 200);
           }
         }
       }
@@ -116,4 +121,4 @@ export default function SideNav({
       </span>
     </div>
   );
-}
+});

--- a/public/globals.css
+++ b/public/globals.css
@@ -107,6 +107,16 @@ ul {
   margin-left: 16px;
 }
 
+ol {
+  list-style: decimal;
+  margin-top: 16px;
+  margin-left: 16px;
+}
+
+ol li::marker {
+  color: var(--default-text-color);
+}
+
 li > ul {
   margin-top: 0px;
   margin-left: 16px;


### PR DESCRIPTION
Fixes some issues from #93 

- https://github.com/open-metadata/docs-v1/issues/93#issuecomment-1524716111
- https://github.com/open-metadata/docs-v1/issues/93#issuecomment-1524717615

- [x] Ordered list not showing numbers
- [x] Page scrolling to the top every time the side nav collapse or expands
- [x] Added tracking pixel snippet
- [x] Fixed Arrow key traversing not working in the search results when no search text is present
