### PR TITLE
fix: selected version flickering after each page load

### DIFF
--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -26,12 +26,13 @@ const searchClient = algoliasearch(
   process.env.NEXT_PUBLIC_ALGOLIA_API_KEY
 );
 
-export default function TopNav() {
+interface TopNavProps {
+  versionsList: Array<SelectOption<string>>;
+}
+
+export default function TopNav({ versionsList }: TopNavProps) {
   const router = useRouter();
   const { docVersion, onChangeDocVersion } = useDocVersionContext();
-  const [versions, setVersions] = useState<Array<SelectOption<string>>>(
-    VERSION_SELECT_DEFAULT_OPTIONS
-  );
 
   const handleVersionChange = (value: string) => {
     const path =
@@ -41,30 +42,6 @@ export default function TopNav() {
 
     router.push(path);
   };
-
-  const fetchVersionsList = async () => {
-    try {
-      const res = await fetch("/api/getVersionsList");
-
-      const parsedResponse = await res.json();
-
-      if (res.status === 200) {
-        setVersions(parsedResponse);
-      } else {
-        setVersions(VERSION_SELECT_DEFAULT_OPTIONS);
-        console.error(
-          "An error occurred while fetching versions list:",
-          parsedResponse
-        );
-      }
-    } catch (error) {
-      setVersions(VERSION_SELECT_DEFAULT_OPTIONS);
-    }
-  };
-
-  useEffect(() => {
-    fetchVersionsList();
-  }, []);
 
   useEffect(() => {
     const regexToMatchVersionString = /v(\d+\.\d+\.\d+)/g;
@@ -87,10 +64,10 @@ export default function TopNav() {
         <Link href={docVersion ? getUrlWithVersion("/") : "/"}>
           <SvgLogo />
         </Link>
-        {!isEmpty(versions) && (
+        {!isEmpty(versionsList) && (
           <SelectDropdown
             value={docVersion}
-            options={versions}
+            options={versionsList}
             onChange={handleVersionChange}
           />
         )}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_VERSION } from "./../constants/version.constants";
+import {
+  DEFAULT_VERSION,
+  VERSION_SELECT_DEFAULT_OPTIONS,
+} from "./../constants/version.constants";
 import fs from "fs";
 import { join, basename } from "path";
 import findIndex from "lodash/findIndex";
@@ -101,3 +104,20 @@ export function getMenu(version?: string) {
 
   return menu;
 }
+
+export const getVersionsList = () => {
+  try {
+    const versionsArray = fs.readdirSync(ARTICLES_DIRECTORY);
+    const versionsList = versionsArray.map((version) => ({
+      label: version,
+      value: version,
+    }));
+
+    versionsList.sort();
+    versionsList.reverse();
+
+    return versionsList;
+  } catch (error) {
+    return VERSION_SELECT_DEFAULT_OPTIONS;
+  }
+};

--- a/pages/[version]/[...slug].tsx
+++ b/pages/[version]/[...slug].tsx
@@ -3,6 +3,7 @@ import {
   getArticleSlugFromString,
   getArticleSlugs,
   getMenu,
+  getVersionsList,
 } from "../../lib/api";
 import fs from "fs";
 import matter from "gray-matter";
@@ -25,17 +26,19 @@ import SkeletonLoader from "../../components/common/SkeletonLoader/SkeletonLoade
 import { SKELETON_PARAGRAPH_WIDTHS } from "../../constants/SkeletonLoader.constants";
 import { useRouteChangingContext } from "../../context/RouteChangingContext";
 import Script from "next/script";
+import { SelectOption } from "../../components/SelectDropdown/SelectDropdown";
 
 interface Props {
   menu: MenuItem[];
   content: string;
   slug: string[];
+  versionsList: Array<SelectOption<string>>;
 }
 
 // Offset of 152px = 112px top nav-bar height + 140px top margin to show the link properly
 const SCROLLING_OFFSET = 252;
 
-export default function Article({ menu, content, slug }: Props) {
+export default function Article({ menu, content, slug, versionsList }: Props) {
   const router = useRouter();
   const { isRouteChanging } = useRouteChangingContext();
   const [sideNavCollapsed, setSideNavCollapsed] = useState<boolean>(false);
@@ -105,7 +108,7 @@ export default function Article({ menu, content, slug }: Props) {
       <ErrorBoundary>
         <StepsContextProvider>
           <div className="flex flex-col">
-            <TopNav />
+            <TopNav versionsList={versionsList} />
             <CategoriesNav menu={menu} />
             <div className="flex">
               <SideNav
@@ -160,6 +163,8 @@ export async function getServerSideProps(context) {
     const versionFormat = /v(\d+\.\d+\.\d+)/g;
     const isVersionPresent = versionFormat.test(context.params.version);
 
+    const versionsList: Array<SelectOption<string>> = getVersionsList();
+
     if (isVersionPresent) {
       let location = `/${context.params.version}/${context.params.slug.join(
         "/"
@@ -190,6 +195,7 @@ export async function getServerSideProps(context) {
         props["menu"] = menu;
         props["content"] = content;
         props["slug"] = context.params.slug;
+        props["versionsList"] = versionsList;
       }
     }
 

--- a/pages/[version]/index.tsx
+++ b/pages/[version]/index.tsx
@@ -8,7 +8,7 @@ import Button from "../../components/common/Button/Button";
 import { ReactComponent as ArrowRight } from "../../images/icons/arrow-right.svg";
 import TopNav from "../../components/TopNav/TopNav";
 import CategoriesNav from "../../components/CategoriesNav/CategoriesNav";
-import { getMenu } from "../../lib/api";
+import { getMenu, getVersionsList } from "../../lib/api";
 import Footer from "../../components/Footer/Footer";
 import { getUrlWithVersion } from "../../utils/CommonUtils";
 import {
@@ -18,13 +18,20 @@ import {
 import { useRouteChangingContext } from "../../context/RouteChangingContext";
 import SkeletonLoader from "../../components/common/SkeletonLoader/SkeletonLoader";
 import { SkeletonWidth } from "../../enums/SkeletonLoder.enum";
+import { MenuItem } from "../../interface/common.interface";
+import { SelectOption } from "../../components/SelectDropdown/SelectDropdown";
 
-export default function Index({ menu }) {
+interface Props {
+  menu: MenuItem[];
+  versionsList: Array<SelectOption<string>>;
+}
+
+export default function Index({ menu, versionsList }: Props) {
   const { isRouteChanging } = useRouteChangingContext();
 
   return (
     <>
-      <TopNav />
+      <TopNav versionsList={versionsList} />
       <CategoriesNav menu={menu} />
       <div className="home-page">
         {isRouteChanging ? (
@@ -133,12 +140,13 @@ export async function getServerSideProps(context) {
     const versionFormat = /(v\d\.*\d*)/g;
     const isVersionPresent = versionFormat.test(context.params.version);
     let menu = [];
+    const versionsList: Array<SelectOption<string>> = getVersionsList();
 
     if (isVersionPresent) {
       menu = getMenu(context.params.version);
     }
     return {
-      props: { menu },
+      props: { menu, versionsList },
     };
   } catch {
     return {

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -15,8 +15,14 @@ import { useRouteChangingContext } from "../context/RouteChangingContext";
 import { MenuItem } from "../interface/common.interface";
 import { getCategoryByIndex } from "../lib/utils";
 import { fetchMenuList, getVersionFromUrl } from "../utils/CommonUtils";
+import { SelectOption } from "../components/SelectDropdown/SelectDropdown";
+import { getVersionsList } from "../lib/api";
 
-function ErrorComponent() {
+interface Props {
+  versionsList: Array<SelectOption<string>>;
+}
+
+function ErrorComponent({ versionsList }: Props) {
   const router = useRouter();
   const { docVersion, onChangeDocVersion } = useDocVersionContext();
   const { isRouteChanging } = useRouteChangingContext();
@@ -47,7 +53,7 @@ function ErrorComponent() {
 
   return (
     <div className="flex flex-col">
-      <TopNav />
+      <TopNav versionsList={versionsList} />
       <CategoriesNav menu={menu} />
       <div className="flex">
         <SideNav
@@ -91,3 +97,17 @@ function ErrorComponent() {
 }
 
 export default ErrorComponent;
+
+export async function getServerSideProps() {
+  try {
+    const versionsList: Array<SelectOption<string>> = getVersionsList();
+
+    return {
+      props: { versionsList },
+    };
+  } catch {
+    return {
+      notFound: true,
+    };
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,8 +19,14 @@ import { MenuItem } from "../interface/common.interface";
 import { useRouteChangingContext } from "../context/RouteChangingContext";
 import SkeletonLoader from "../components/common/SkeletonLoader/SkeletonLoader";
 import { SkeletonWidth } from "../enums/SkeletonLoder.enum";
+import { SelectOption } from "../components/SelectDropdown/SelectDropdown";
+import { getMenu, getVersionsList } from "../lib/api";
 
-export default function Index() {
+interface Props {
+  versionsList: Array<SelectOption<string>>;
+}
+
+export default function Index({ versionsList }: Props) {
   const { docVersion } = useDocVersionContext();
   const { isRouteChanging } = useRouteChangingContext();
   const [menu, setMenu] = useState<MenuItem[]>([]);
@@ -36,7 +42,7 @@ export default function Index() {
 
   return (
     <>
-      <TopNav />
+      <TopNav versionsList={versionsList} />
       <CategoriesNav menu={menu} />
       <div className="home-page">
         {isRouteChanging ? (
@@ -136,4 +142,18 @@ export default function Index() {
       </div>
     </>
   );
+}
+
+export async function getServerSideProps() {
+  try {
+    const versionsList: Array<SelectOption<string>> = getVersionsList();
+
+    return {
+      props: { versionsList },
+    };
+  } catch {
+    return {
+      notFound: true,
+    };
+  }
 }


### PR DESCRIPTION
Fixes issue in comment https://github.com/open-metadata/docs-v1/issues/93#issuecomment-1531496673
Fixes #88 

- [x] Fixed an issue where the selected version was flickering after each page load
- [x] Order of version selection options changed to show the latest version first in the list

https://user-images.githubusercontent.com/51777795/235685130-2e507a50-855b-443e-8762-50df9a14214a.mov
