### PR TITLE
feat: stable versions display and snapshot version ignore logic

### DIFF
--- a/components/SelectDropdown/SelectDropdown.module.css
+++ b/components/SelectDropdown/SelectDropdown.module.css
@@ -46,7 +46,19 @@
 }
 
 .SelectOptions {
+  display: flex;
+  gap: 8px;
   padding: 4px 12px;
+}
+
+.StableLabel {
+  font-size: 12px;
+  line-height: 15px;
+  padding: 0px 6px;
+  align-self: center;
+  border-radius: 9px;
+  color: white;
+  background-color: var(--primary-color);
 }
 
 .SelectOptions:hover {

--- a/components/SelectDropdown/SelectDropdown.tsx
+++ b/components/SelectDropdown/SelectDropdown.tsx
@@ -4,6 +4,7 @@ import { ReactComponent as ArrowDownIcon } from "../../images/icons/arrow-down.s
 import classNames from "classnames";
 import { getSelectedOption } from "../../utils/SelectDropdownUtils";
 import { uniqueId } from "lodash";
+import { STABLE_VERSION } from "../../constants/version.constants";
 
 export interface SelectOption<V> {
   label: string;
@@ -107,13 +108,16 @@ function SelectDropdown<T>({
         id={`dropdown-container-${idString}`}
         style={{ top: `calc(${height} + 4px)` ?? "", minWidth: width ?? "" }}
       >
-        {options.map((option, idx) => (
+        {options.map((option) => (
           <span
             className={styles.SelectOptions}
-            key={`${option.label}-${idx}`}
+            key={option.label}
             onClick={() => handleOptionClick(option)}
           >
-            {option.label}
+            <span>{option.label}</span>
+            {option.label === STABLE_VERSION ? (
+              <span className={styles.StableLabel}>Stable</span>
+            ) : null}
           </span>
         ))}
       </div>

--- a/constants/version.constants.ts
+++ b/constants/version.constants.ts
@@ -1,6 +1,7 @@
 import { SelectOption } from "../components/SelectDropdown/SelectDropdown";
 
 export const DEFAULT_VERSION = "v1.0.0";
+export const STABLE_VERSION = "v1.0.0";
 
 export const VERSION_SELECT_DEFAULT_OPTIONS: Array<SelectOption<string>> = [
   {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -111,9 +111,9 @@ export const getVersionsList = () => {
   try {
     const versionsArray = fs.readdirSync(ARTICLES_DIRECTORY);
     const versionsList = versionsArray
-      // content folder now also has partials folder with the versions folders
+      // content folder now also has other folders like partial or the next release snapshot content with the versions folders
       // this check is to select only versions folders
-      .filter((version) => /v(\d+\.\d+\.\d+)/g.test(version))
+      .filter((version) => /^v(\d+\.\d+\.\d+)$/g.test(version))
       .map((version) => ({
         label: version,
         value: version,


### PR DESCRIPTION
- [x] Added a stable badge to show for stable version in the version selector dropdown

https://github.com/open-metadata/docs-v1/assets/51777795/675a0764-7fc7-4603-b829-2756380e90c9

- [x] Added logic to ignore the snapshot version option to show in the version selector dropdown