### PR TITLE
Fixed the styling for heading tags

### DIFF
--- a/components/Heading/Heading.module.css
+++ b/components/Heading/Heading.module.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   color: rgb(26, 31, 54);
+  margin-top: 32px;
 }
 
 .CopiedText {
@@ -26,6 +27,5 @@
   display: block;
   visibility: hidden;
   text-decoration: none;
-  margin-top: 32px;
   pointer-events: none;
 }


### PR DESCRIPTION
<img width="1439" alt="Screenshot 2023-06-03 at 9 21 54 AM" src="https://github.com/open-metadata/docs-v1/assets/51777795/26999640-15c1-4b0c-b7fa-af1ce425c459">

<img width="1440" alt="Screenshot 2023-06-03 at 9 22 06 AM" src="https://github.com/open-metadata/docs-v1/assets/51777795/b0940f2e-89f5-4bcd-9bed-09e0cd3e05fc">
