### PR TITLE
fix#10652: heading tag spacing issue

### DIFF
--- a/components/Heading/Heading.tsx
+++ b/components/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "./Heading.module.css";
 import HeadingElement from "./HeadingElement";
 
@@ -21,11 +21,15 @@ export function Heading({ id = "", level = 1, children, className }) {
         level={level}
       >
         <a id={id} className={styles.HashLink} />
-        {children}
+        <span>{children}</span>
         {copied ? (
           <span className={styles.CopiedText}>Copied</span>
         ) : (
-          <span className={styles.Icon} onClick={copyLinkUnbound}>
+          <span
+            className={styles.Icon}
+            title="Copy Link"
+            onClick={copyLinkUnbound}
+          >
             <svg
               width="14"
               height="17"

--- a/markdoc/nodes/heading.markdoc.ts
+++ b/markdoc/nodes/heading.markdoc.ts
@@ -1,4 +1,26 @@
 import { Tag } from "@markdoc/markdoc";
+import { isEmpty, isString, toArray } from "lodash";
+
+// Logic to extract texts from the inline nodes
+// Example: # This is a `Heading`
+// should have id as "This-is-a-Heading"
+function getChildrenTexts(children): string[] {
+  if (isEmpty(children)) {
+    return [];
+  }
+
+  return toArray(children).reduce((prevValue, childNode) => {
+    if (isString(childNode)) {
+      return [...prevValue, childNode];
+    } else if (!isEmpty(childNode.attributes)) {
+      return [...prevValue, childNode.attributes.content];
+    } else if (!isEmpty(childNode.children)) {
+      return [...prevValue, ...getChildrenTexts(childNode.children)];
+    } else {
+      return;
+    }
+  }, []);
+}
 
 function generateID(children, attributes) {
   if (attributes.id && typeof attributes.id === "string") {
@@ -7,7 +29,8 @@ function generateID(children, attributes) {
   return children
     .filter((child) => typeof child === "string")
     .join(" ")
-    .replace(/[?]/g, "")
+    .replace(/[?:\-()%$#/@!;.,\/\\\[\]+=_]/g, "")
+    .trim()
     .replace(/\s+/g, "-")
     .toLowerCase();
 }
@@ -24,7 +47,8 @@ export const heading = {
   transform(node, config) {
     const attributes = node.transformAttributes(config);
     const children = node.transformChildren(config);
-    const id = generateID(children, attributes);
+
+    const id = generateID(getChildrenTexts(children), attributes);
 
     return new Tag(this.render, { ...attributes, id }, children);
   },


### PR DESCRIPTION
Fixes [#10652](https://github.com/open-metadata/OpenMetadata/issues/10652)
- [x] Fixed the spacing for the `Heading` tags when used with other inline nodes for content.

<img width="727" alt="Screenshot 2023-06-30 at 4 37 38 PM" src="https://github.com/open-metadata/docs-v1/assets/51777795/d6e3ddd0-6619-41db-b3d9-57c17e1ac763">

- [x] Fixed the logic to generate `id` for the heading from the content.