### PR TITLE
fix: update paths for sdks

### DIFF
--- a/constants/categoriesNav.constants.ts
+++ b/constants/categoriesNav.constants.ts
@@ -1,5 +1,5 @@
 export const API_AND_SDK_MENU_ITEMS = [
   { label: "REST API", value: "/swagger.html", withoutVersionPath: true },
-  { label: "Python", value: "/python-sdk", category: "SDK" },
-  { label: "Java", value: "/java-sdk", category: "SDK" },
+  { label: "Python", value: "/sdk/python", category: "SDK" },
+  { label: "Java", value: "/sdk/java", category: "SDK" },
 ];


### PR DESCRIPTION
SDK docs are now at e.g. https://docs.open-metadata.org/v1.1.0/sdk/java