### PR TITLE
Handle two digit version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ search:
 
 .PHONY: docker-build
 docker-build:
-	docker build -t openmetadata-docs-v1:local .
+	docker build -t openmetadata-docs:local .

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -60,7 +60,7 @@ export default function TopNav({ versionsList }: TopNavProps) {
   }, []);
 
   useEffect(() => {
-    const regexToMatchVersionString = /v(\d+\.\d+\.\d+)/g;
+    const regexToMatchVersionString = /v(\d+\.\d+)/g;
 
     if (router.pathname !== "/_error") {
       if (

--- a/constants/version.constants.ts
+++ b/constants/version.constants.ts
@@ -1,7 +1,7 @@
 import { SelectOption } from "../components/SelectDropdown/SelectDropdown";
 
-export const DEFAULT_VERSION = "v1.1.2";
-export const STABLE_VERSION = "v1.1.2";
+export const DEFAULT_VERSION = "v1.1";
+export const STABLE_VERSION = "v1.1";
 
 export const VERSION_SELECT_DEFAULT_OPTIONS: Array<SelectOption<string>> = [
   {
@@ -10,4 +10,4 @@ export const VERSION_SELECT_DEFAULT_OPTIONS: Array<SelectOption<string>> = [
   },
 ];
 
-export const REGEX_VERSION_MATCH = /v(\d+\.\d+\.\d+)/g;
+export const REGEX_VERSION_MATCH = /v(\d+\.\d+)/g;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -113,7 +113,7 @@ export const getVersionsList = () => {
     const versionsList = versionsArray
       // content folder now also has other folders like partial or the next release snapshot content with the versions folders
       // this check is to select only versions folders
-      .filter((version) => /^v(\d+\.\d+\.\d+)$/g.test(version))
+      .filter((version) => /^v(\d+\.\d+)$/g.test(version))
       .map((version) => ({
         label: version,
         value: version,

--- a/pages/[version]/[...slug].tsx
+++ b/pages/[version]/[...slug].tsx
@@ -108,7 +108,7 @@ export async function getServerSideProps(context) {
     const props = { menu: [], content: "", slug: [] };
 
     // Check if the version field passed in context params is proper version format
-    const versionFormat = /v(\d+\.\d+\.\d+)/g;
+    const versionFormat = /v(\d+\.\d+)/g;
     const isVersionPresent = versionFormat.test(context.params.version);
 
     const versionsList: Array<SelectOption<string>> = getVersionsList();

--- a/pages/[version]/index.tsx
+++ b/pages/[version]/index.tsx
@@ -149,7 +149,7 @@ export default function Index({ menu, versionsList }: Props) {
 export async function getServerSideProps(context) {
   try {
     // Check if the version field passed in context params is proper version format
-    const versionFormat = /(v\d\.*\d*)/g;
+    const versionFormat = /(v\d\.\d*)/g;
     const isVersionPresent = versionFormat.test(context.params.version);
     let menu = [];
     const versionsList: Array<SelectOption<string>> = getVersionsList();


### PR DESCRIPTION
Instead of `x.y.z` we'll handle versions as `x.y` to make it easier for us to evolve during minor releases