### PR TITLE
#193: Refactored side nav bar for how to guides page

### DIFF
--- a/components/HowToGuidesHeader/HowToGuidesHeader.tsx
+++ b/components/HowToGuidesHeader/HowToGuidesHeader.tsx
@@ -32,7 +32,7 @@ function HowToGuidesHeader() {
               padding: "8px 12px",
             }}
             type="link"
-            href="/how-to-guides/openmetadata/data-discovery"
+            href="/how-to-guides/data-discovery"
           >
             <span>Get Started</span>
             <MdOutlineArrowForwardIos size={10} />

--- a/components/SideNav/ListItem.interface.ts
+++ b/components/SideNav/ListItem.interface.ts
@@ -1,0 +1,6 @@
+import { MenuItem } from "../../interface/common.interface";
+
+export interface ListItemProps {
+  item: MenuItem;
+  fontWeight?: number;
+}

--- a/components/SideNav/ListItem.tsx
+++ b/components/SideNav/ListItem.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import { isNil } from "lodash";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -6,17 +7,11 @@ import { useDocVersionContext } from "../../context/DocVersionContext";
 import { ReactComponent as ArrowDown } from "../../images/icons/drop-arrow-down.svg";
 import { ReactComponent as ArrowRight } from "../../images/icons/drop-arrow-right.svg";
 import { ReactComponent as CollateIcon } from "../../images/icons/ic-collate.svg";
-import { MenuItem } from "../../interface/common.interface";
 import { getUrlWithVersion } from "../../utils/CommonUtils";
+import { ListItemProps } from "./ListItem.interface";
 import styles from "./SideNav.module.css";
 
-export default function ListItem({
-  item,
-  fontWeight,
-}: {
-  item: MenuItem;
-  fontWeight?: number;
-}) {
+export default function ListItem({ item, fontWeight }: Readonly<ListItemProps>) {
   const router = useRouter();
   const { docVersion } = useDocVersionContext();
   const linkRef = useRef<HTMLAnchorElement>();
@@ -65,7 +60,10 @@ export default function ListItem({
 
   useEffect(() => {
     // Logic to get the selected side nav item into view after page load
-    if (linkRef.current && linkRef.current.className.includes("ActiveLink")) {
+    if (
+      !isNil(linkRef.current) &&
+      linkRef.current.className.includes("ActiveLink")
+    ) {
       linkRef.current.scrollIntoView({ block: "center", inline: "center" });
     }
   }, [isActive, linkRef]);

--- a/components/SideNav/SideNav.tsx
+++ b/components/SideNav/SideNav.tsx
@@ -9,6 +9,7 @@ import { ReactComponent as CollapseLeftIcon } from "../../images/icons/collapse-
 import { ReactComponent as CollapseRightIcon } from "../../images/icons/collapse-right.svg";
 import { ReactComponent as OverviewIcon } from "../../images/icons/overview-icon.svg";
 import { getCategoryByIndex } from "../../lib/utils";
+import { getSideNavItems } from "../../utils/SideNavUtils";
 import SkeletonLoader from "../common/SkeletonLoader/SkeletonLoader";
 import ListItem from "./ListItem";
 import styles from "./SideNav.module.css";
@@ -42,7 +43,10 @@ export default forwardRef(function SideNav(
     [menuItems, category]
   );
 
-  const childItems = useMemo(() => item?.children ?? [], [item]);
+  const childItems = useMemo(
+    () => getSideNavItems(item, router.asPath),
+    [item, router.asPath]
+  );
 
   useEffect(() => {
     const scrollEventListener = () => {

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -14,7 +14,7 @@ import {
 import { useDocVersionContext } from "../../context/DocVersionContext";
 import { useNavBarCollapsedContext } from "../../context/NavBarCollapseContext";
 import { SearchContextProvider } from "../../context/SearchContext";
-import { ReactComponent as API } from "../../images/icons/api.svg";
+import { ReactComponent as Api } from "../../images/icons/api.svg";
 import { ReactComponent as Cloud } from "../../images/icons/cloud.svg";
 import { ReactComponent as Github } from "../../images/icons/github.svg";
 import { ReactComponent as SvgLogo } from "../../images/icons/omd.svg";
@@ -33,7 +33,7 @@ interface TopNavProps {
   versionsList: Array<SelectOption<string>>;
 }
 
-export default function TopNav({ versionsList }: TopNavProps) {
+export default function TopNav({ versionsList }: Readonly<TopNavProps>) {
   const router = useRouter();
   const [displayNavBarCollapseButton, setDisplayNavBarCollapseButton] =
     useState(false);
@@ -111,6 +111,9 @@ export default function TopNav({ versionsList }: TopNavProps) {
         <InstantSearch
           indexName={`openmetadata-v1-${docVersion}`}
           searchClient={searchClient}
+          future={{
+            preserveSharedStateOnUnmount: false,
+          }}
         >
           <Search />
         </InstantSearch>
@@ -127,7 +130,7 @@ export default function TopNav({ versionsList }: TopNavProps) {
           <Github />
         </a>
         <a href="/swagger.html" target="_blank" title="Swagger">
-          <API />
+          <Api />
         </a>
         <a
           className="btn fw-500 btn-primary rounded-pill"

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -14,11 +14,11 @@ import {
 import { useDocVersionContext } from "../../context/DocVersionContext";
 import { useNavBarCollapsedContext } from "../../context/NavBarCollapseContext";
 import { SearchContextProvider } from "../../context/SearchContext";
-import { ReactComponent as Api } from "../../images/icons/api.svg";
-import { ReactComponent as Cloud } from "../../images/icons/cloud.svg";
-import { ReactComponent as Github } from "../../images/icons/github.svg";
-import { ReactComponent as SvgLogo } from "../../images/icons/omd.svg";
-import { ReactComponent as Slack } from "../../images/icons/slack.svg";
+import { ReactComponent as ApiIcon } from "../../images/icons/api.svg";
+import { ReactComponent as CloudIcon } from "../../images/icons/cloud.svg";
+import { ReactComponent as GithubIcon } from "../../images/icons/github.svg";
+import { ReactComponent as OMDIcon } from "../../images/icons/omd.svg";
+import { ReactComponent as SlackIcon } from "../../images/icons/slack.svg";
 import { getUrlWithVersion } from "../../utils/CommonUtils";
 import Search from "../Search/Search";
 import SelectDropdown, { SelectOption } from "../SelectDropdown/SelectDropdown";
@@ -88,7 +88,7 @@ export default function TopNav({ versionsList }: Readonly<TopNavProps>) {
       <div className={styles.CollapsedDivContainer}>
         <div className={styles.LogoContainer}>
           <Link href={docVersion ? getUrlWithVersion("/", docVersion) : "/"}>
-            <SvgLogo />
+            <OMDIcon />
           </Link>
           {!isEmpty(versionsList) && (
             <SelectDropdown
@@ -120,17 +120,17 @@ export default function TopNav({ versionsList }: Readonly<TopNavProps>) {
       </SearchContextProvider>
       <div className={styles.IconContainer}>
         <a href="https://slack.open-metadata.org" target="_blank" title="Slack">
-          <Slack />
+          <SlackIcon />
         </a>
         <a
           href="https://github.com/open-metadata/OpenMetadata"
           target="_blank"
           title="Github"
         >
-          <Github />
+          <GithubIcon />
         </a>
         <a href="/swagger.html" target="_blank" title="Swagger">
-          <Api />
+          <ApiIcon />
         </a>
         <a
           className="btn fw-500 btn-primary rounded-pill"
@@ -138,7 +138,7 @@ export default function TopNav({ versionsList }: Readonly<TopNavProps>) {
           target="_blank"
         >
           <button className={styles.CloudBtn}>
-            <Cloud />
+            <CloudIcon />
           </button>
         </a>
       </div>

--- a/components/common/SkeletonLoader/SkeletonLoader.tsx
+++ b/components/common/SkeletonLoader/SkeletonLoader.tsx
@@ -16,7 +16,7 @@ function SkeletonLoader({
   showBreadcrumb = false,
   title = DEFAULT_TITLE,
   paragraph = DEFAULT_PARAGRAPH,
-}: SkeletonLoaderProps) {
+}: Readonly<SkeletonLoaderProps>) {
   return (
     <div className={classNames(styles.Container, className)}>
       {showBreadcrumb && getSkeletonBreadcrumbs()}

--- a/components/modals/APISearchModal/APISearchModal.tsx
+++ b/components/modals/APISearchModal/APISearchModal.tsx
@@ -1,4 +1,5 @@
 import algoliasearch from "algoliasearch/lite";
+import { isNil } from "lodash";
 import { useEffect } from "react";
 import ReactDOM from "react-dom";
 import { InstantSearch } from "react-instantsearch";
@@ -23,7 +24,7 @@ function APISearchModal({ handleMaskClick }: APISearchModalProps) {
     setTimeout(() => {
       const inputElement = document.getElementById("search-input");
 
-      inputElement && inputElement.focus();
+      !isNil(inputElement) && inputElement.focus();
     }, 50);
   }, []);
 
@@ -38,6 +39,9 @@ function APISearchModal({ handleMaskClick }: APISearchModalProps) {
           <InstantSearch
             indexName={`openmetadata-v1-${docVersion}`}
             searchClient={searchClient}
+            future={{
+              preserveSharedStateOnUnmount: false, // Library recommendation to keep the old behavior
+            }}
           >
             <Search
               className={styles.SearchContainer}

--- a/constants/SideNav.constants.ts
+++ b/constants/SideNav.constants.ts
@@ -1,0 +1,1 @@
+export const HOW_TO_GUIDES_MENU_ITEM_KEY = "how-to-guides";

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,16 +1,11 @@
-import {
-  DEFAULT_VERSION,
-  VERSION_SELECT_DEFAULT_OPTIONS,
-} from "./../constants/version.constants";
 import fs from "fs";
-import { join, basename } from "path";
-import findIndex from "lodash/findIndex";
-import matter from "gray-matter";
+import { join } from "path";
 import slugify from "slugify";
 import {
   ARTICLES_DIRECTORY,
   PARTIALS_DIRECTORY,
 } from "../constants/common.constants";
+import { VERSION_SELECT_DEFAULT_OPTIONS } from "./../constants/version.constants";
 
 export function getAllFilesInDirectory(
   articleDirectory: string,
@@ -34,77 +29,6 @@ export function getArticleSlugs() {
 
 export function getArticleSlugFromString(pathname) {
   return slugify(pathname).toLowerCase();
-}
-
-export function getArticleBySlug(slug, fields = []) {
-  const realSlug = basename(slug).replace(/\.md$/, "");
-  const fullPath = slug;
-  const fileContents = fs.readFileSync(fullPath, "utf8");
-  const { data, content } = matter(fileContents);
-
-  const items = {};
-
-  // Ensure only the minimal needed data is exposed
-  fields.forEach((field) => {
-    if (field === "slug") {
-      items[field] = realSlug;
-    }
-    if (field === "content") {
-      items[field] = content;
-    }
-    if (data[field]) {
-      items[field] = data[field];
-    }
-  });
-
-  return items;
-}
-
-export function getAllArticles(fields = []) {
-  const slugs = getArticleSlugs();
-  const posts = slugs.map((slug) => getArticleBySlug(slug, fields));
-  return posts;
-}
-
-export function getMenu(version?: string) {
-  const menu = [];
-  const fullPath = join(
-    ARTICLES_DIRECTORY,
-    version ? version : DEFAULT_VERSION,
-    `menu.md`
-  );
-  const fileContents = fs.readFileSync(fullPath, "utf8");
-  const data = matter(fileContents);
-
-  let menuRoot = menu;
-  let objRoot = menu;
-
-  const flatMenu = data.data["site_menu"];
-
-  for (const index in flatMenu) {
-    const item = flatMenu[index];
-    const category = item["category"].split("/");
-    // Move to the depth we need
-    for (const depth in category) {
-      const menu_key = slugify(category[depth].trim().toLowerCase());
-      let exist = findIndex(menuRoot, { menu_key: menu_key });
-      if (exist < 0) {
-        menuRoot.push({
-          menu_key: menu_key,
-          name: category[depth].trim(),
-          depth: depth,
-          children: [],
-        });
-        exist = findIndex(menuRoot, { menu_key: menu_key });
-      }
-      objRoot = menuRoot[exist];
-      menuRoot = menuRoot[exist]["children"];
-    }
-    Object.assign(objRoot, item);
-    menuRoot = menu;
-  }
-
-  return menu;
 }
 
 export const getVersionsList = () => {

--- a/pages/[version]/[...slug].tsx
+++ b/pages/[version]/[...slug].tsx
@@ -32,7 +32,7 @@ export default function Article({
   slug,
   versionsList,
   partials,
-}: Props) {
+}: Readonly<Props>) {
   const ast = useMemo(() => Markdoc.parse(content), [content]);
 
   const formattedPartialsObj = useMemo(

--- a/pages/api/getMenu.ts
+++ b/pages/api/getMenu.ts
@@ -24,18 +24,19 @@ export default function handler(req, res) {
     for (const index in flatMenu) {
       const item = flatMenu[index];
       const category = item["category"].split("/");
+      const url = item["url"].slice(1).split("/");
       // Move to the depth we need
       for (const depth in category) {
-        const menu_key = slugify(category[depth].trim().toLowerCase());
-        let exist = findIndex(menuRoot, { menu_key: menu_key });
+        const menu_key = slugify(url[depth].trim().toLowerCase());
+        let exist = findIndex(menuRoot, { menu_key });
         if (exist < 0) {
           menuRoot.push({
-            menu_key: menu_key,
+            menu_key,
             name: category[depth].trim(),
-            depth: depth,
+            depth,
             children: [],
           });
-          exist = findIndex(menuRoot, { menu_key: menu_key });
+          exist = findIndex(menuRoot, { menu_key });
         }
         objRoot = menuRoot[exist];
         menuRoot = menuRoot[exist]["children"];

--- a/utils/SideNavUtils.ts
+++ b/utils/SideNavUtils.ts
@@ -1,0 +1,14 @@
+import { HOW_TO_GUIDES_MENU_ITEM_KEY } from "../constants/SideNav.constants";
+import { MenuItem } from "../interface/common.interface";
+import { getCategoryByIndex } from "../lib/utils";
+
+export const getSideNavItems = (item: MenuItem, path) => {
+  if (item?.menu_key === HOW_TO_GUIDES_MENU_ITEM_KEY) {
+    const subCategory = getCategoryByIndex(path, 3);
+    return (
+      item?.children.filter((child) => child.menu_key === subCategory) ?? []
+    );
+  }
+
+  return item?.children ?? [];
+};


### PR DESCRIPTION
The how-to-guides pages sections will now only show the relevant section items in the left side navigation bar
fixes #193 


https://github.com/open-metadata/docs-v1/assets/51777795/6a39bcec-c2c6-4a3e-baae-75511764c111

