### PR TITLE
Minor: Add SAS connector in homepage connectors section

### DIFF
--- a/components/ConnectorsInfo/ConnectorsInfo.constants.ts
+++ b/components/ConnectorsInfo/ConnectorsInfo.constants.ts
@@ -1,4 +1,6 @@
-export const CONNECTORS = [
+import { ConnectorCategory } from "./ConnectorsInfo.interface";
+
+export const CONNECTORS: Array<ConnectorCategory> = [
   {
     connector: "Database",
     services: [
@@ -161,6 +163,12 @@ export const CONNECTORS = [
         url: "/connectors/database/pinotdb",
         icon: "./images/connectors/pinot.png",
         name: "Pinot",
+      },
+      {
+        url: "/connectors/database/sas",
+        icon: "./images/connectors/sas.png",
+        name: "SAS",
+        supportedVersion: "v1.3.x",
       },
       {
         url: "/connectors/database/sqlite",

--- a/components/ConnectorsInfo/ConnectorsInfo.interface.ts
+++ b/components/ConnectorsInfo/ConnectorsInfo.interface.ts
@@ -1,0 +1,10 @@
+export interface ConnectorServiceDetails {
+  url: string;
+  icon: string;
+  name: string;
+  supportedVersion?: string;
+}
+export interface ConnectorCategory {
+  connector: string;
+  services: Array<ConnectorServiceDetails>;
+}

--- a/components/ConnectorsInfo/ConnectorsInfo.tsx
+++ b/components/ConnectorsInfo/ConnectorsInfo.tsx
@@ -1,20 +1,17 @@
 import classNames from "classnames";
-import { sortBy } from "lodash";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useState } from "react";
+import { useDocVersionContext } from "../../context/DocVersionContext";
+import {
+  getConnectorURL,
+  getSortedServiceList,
+} from "../../utils/ConnectorsUtils";
 import Loader from "../common/Loader/Loader";
 import { CONNECTORS } from "./ConnectorsInfo.constants";
+import { ConnectorCategory } from "./ConnectorsInfo.interface";
 import styles from "./ConnectorsInfo.module.css";
 
-interface ConnectorCategory {
-  connector: string;
-  services: {
-    url: string;
-    icon: string;
-    name: string;
-  }[];
-}
 const ConnectorImage = dynamic(() => import("./ConnectorImage"), {
   ssr: false,
   loading: () => <Loader size={28} />,
@@ -23,14 +20,12 @@ const ConnectorImage = dynamic(() => import("./ConnectorImage"), {
 CONNECTORS.unshift({
   connector: "All connectors",
   services: CONNECTORS.reduce((prev, curr) => {
-    return sortBy(
-      [...prev, ...curr.services],
-      [(connector) => connector.name.toLowerCase()]
-    );
+    return [...prev, ...curr.services];
   }, [] as ConnectorCategory["services"]),
 });
 
 export default function ConnectorsInfo() {
+  const { docVersion, onChangeDocVersion } = useDocVersionContext();
   const [selectedTab, setSelectedTab] = useState<ConnectorCategory>(
     CONNECTORS[0]
   );
@@ -55,10 +50,10 @@ export default function ConnectorsInfo() {
       </div>
       <div className={styles.ConnectorsContainer}>
         <div className={styles.ConnectorsGridContainer}>
-          {selectedTab.services.map((connector) => (
+          {getSortedServiceList(selectedTab.services).map((connector) => (
             <Link
               className={styles.ConnectorItem}
-              href={connector.url}
+              href={getConnectorURL(docVersion, connector)}
               key={connector.name}
             >
               <ConnectorImage

--- a/constants/version.constants.ts
+++ b/constants/version.constants.ts
@@ -13,3 +13,4 @@ export const VERSION_SELECT_DEFAULT_OPTIONS: Array<SelectOption<string>> = [
 export const REGEX_VERSION_MATCH = /v\d+\.\d+\.x/;
 export const REGEX_VERSION_MATCH_WITH_SLASH_AT_START =
   /^\/v(\d+(\.*[\d\w])*\.*)/g;
+export const REGEX_TO_EXTRACT_VERSION_NUMBER = /\d+\.\d+/;

--- a/utils/ConnectorsUtils.ts
+++ b/utils/ConnectorsUtils.ts
@@ -1,0 +1,33 @@
+import { sortBy } from "lodash";
+import {
+  ConnectorCategory,
+  ConnectorServiceDetails,
+} from "../components/ConnectorsInfo/ConnectorsInfo.interface";
+import { REGEX_TO_EXTRACT_VERSION_NUMBER } from "../constants/version.constants";
+import { getUrlWithVersion } from "./CommonUtils";
+
+export const getSortedServiceList = (services: ConnectorCategory["services"]) =>
+  sortBy(services, (service) => service.name.toLowerCase());
+
+// Function to check if the current selected version is
+// equal to or greater than the connector supported version
+export const getConnectorURL = (
+  currentVersion: string,
+  connector: ConnectorServiceDetails
+) => {
+  try {
+    // Extract version number from the version strings
+    const currentVersionNumber = Number(
+      REGEX_TO_EXTRACT_VERSION_NUMBER.exec(currentVersion ?? "")[0]
+    );
+    const supportedVersionNumber = Number(
+      REGEX_TO_EXTRACT_VERSION_NUMBER.exec(connector.supportedVersion ?? "")[0]
+    );
+
+    return currentVersionNumber >= supportedVersionNumber
+      ? connector.url
+      : getUrlWithVersion(connector.url, connector.supportedVersion);
+  } catch {
+    return connector.url;
+  }
+};


### PR DESCRIPTION
I worked on

- [x] Adding SAS connector to the homepage

<img width="572" alt="Screenshot 2024-02-06 at 11 59 07 AM" src="https://github.com/open-metadata/docs-v1/assets/51777795/f9a361b1-e6d9-4aaa-9f69-62e76a0f4599">

- [x] Added logic to redirect users to the supported version connector page if current selected version doesn't have the connector