### PR TITLE
Feat #194: Add connector details header component

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Here are the custom markdoc tags to use for desired functionalities.
    - [2. note](#2-note)
    - [3. codeWithLanguageSelector](#3-codeWithLanguageSelector)
    - [4. extraContent](#4-extraContent)
+   - [5. connectorDetailsHeader](#5-connectorDetailsHeader)
+   - [6. connectorInfoCard](#6-connectorInfoCard)
+   - [7. connectorsListContainer](#7-connectorsListContainer)
 - [Tags for Code Preview Functionality](#tags-for-code-preview-functionality)
    - [1. codePreview](#1-codePreview)
    - [2. codeInfoContainer](#2-codeInfoContainer)
@@ -55,6 +58,8 @@ Here are the custom markdoc tags to use for desired functionalities.
 - [Tile](#tile)
    - [1. tilesContainer](#1-tilesContainer)
    - [2. tile](#2-tile)
+
+---
 
 ## Common Tags
 
@@ -214,6 +219,55 @@ Tag to add some extra information in between two steps. This tag can be used ins
 1. parentTagName (type - String)
    The name of the tag you are using it in. For example 'codePreview' or 'stepsContainer'
 
+### 5. connectorDetailsHeader
+
+Tag to show a styled heading for connectors with the connector Icon, development stage, platform availability and feature status.
+
+#### Attributes
+
+1. name (type - String)
+   The name of the container in startCase.
+
+2. stage (type - String)
+   The development stage of the connector.
+   It should be one of two values "PROD"(default value) or "BETA".
+
+3. platform (type - String)
+   The platform the connector is available in to.
+   It should be one of two values "OpenMetadata"(default value) or "Collate".
+
+4. availableFeatures (type - Array<string>)
+   The list of available features for the connector such as "Query Usage", "Lineage" etc.
+
+5. unavailableFeatures (type - Array<string>)
+   The list of unavailable features for the connector such as "DBT", "Owners" etc
+
+### 6. connectorInfoCard
+
+A styled card to show the links to navigate users to the connector details page with a little information about the connector. 
+
+#### Attributes
+
+1. name (type - String)
+   The name of the container in startCase.
+
+2. stage (type - String)
+   The development stage of the connector.
+   It should be one of two values "PROD"(default value) or "BETA".
+
+3. href (type - String)
+   The relative path of the connector details page.
+
+4. platform (type - String)
+   The platform the connector is available in to.
+   It should be one of two values "OpenMetadata"(default value) or "Collate".
+
+### 7. connectorsListContainer
+
+A wrapper tag to envelope the connectorInfoCard tags for a grid view.
+
+---
+
 ## Tags for Code Preview Functionality
 
 For showing code or commands with the explanations by side use following tags:-
@@ -321,6 +375,8 @@ print('This is block 3')
 
 <img width="2032" alt="code-preview-component-gif" src="./public/code-preview-component.gif">
 
+---
+
 ## Tags for Showing Step by Step Information
 
 - [1. stepsContainer](#1-stepsContainer)
@@ -411,6 +467,8 @@ caption="step2 caption" /%}
 ##### Here's the preview of the Stepper functionality
 
 <img width="2032" alt="steps-component-gif" src="./public/steps-component.gif">
+
+---
 
 ## APIs & SDKs page tags
 
@@ -518,6 +576,7 @@ This is a new code
 
 <img width="2032" alt="steps-component-gif" src="./public/code-lang-selector-preview.gif">
 
+---
 
 ## Inline Callout
 
@@ -577,6 +636,8 @@ The first description 3.
 #### Preview of Inline Callout 
 
 <img width="2032" alt="inline-callout" src="./public/inline-callout.png">
+
+---
 
 ## Tile
 

--- a/components/ConnectorDetailsHeader/ConnectorDetailsHeader.interface.ts
+++ b/components/ConnectorDetailsHeader/ConnectorDetailsHeader.interface.ts
@@ -1,0 +1,7 @@
+export interface ConnectorDetailsHeaderProps {
+  name: string;
+  stage: string;
+  platform: string;
+  availableFeatures: Array<string>;
+  unavailableFeatures: Array<string>;
+}

--- a/components/ConnectorDetailsHeader/ConnectorDetailsHeader.module.css
+++ b/components/ConnectorDetailsHeader/ConnectorDetailsHeader.module.css
@@ -1,0 +1,65 @@
+.Container{
+    margin: 32px 0px;
+    display:flex;
+    flex-direction: column;
+    gap: 12px
+}
+
+.Heading{
+    display:flex;
+    justify-content: space-between;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--default-border-color);
+}
+
+.ConnectorName{
+    font-size: 32px;
+    font-weight: 700;
+}
+
+.PlatformDetails{
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 14px;
+    color: var(--gray-text-color);
+}
+
+.PlatformIcon{
+    padding: 4px;
+    background-color: var(--connector-icon-bg-color);
+    border: 1px solid var(--default-border-color);
+    border-radius: 12px;
+}
+
+.ImageContainer{
+    background-color: var(--connector-icon-bg-color);
+    padding: 12px;
+    border: 1px solid var(--default-border-color);
+    border-radius: 28px;
+}
+
+.SubHeading{
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.FeatureTag{
+    padding: 4px 10px;
+    font-size: 12px;
+    border-radius: 14px;
+    width: fit-content;
+}
+
+.AvailableFeature{
+    color: var(--green-tag-color);
+    border: 1px solid var(--green-tag-color);
+    background-color: var(--green-tag-bg-color);
+}
+
+.UnavailableFeature{
+    color: var(--orange-tag-color);
+    border: 1px solid var(--orange-tag-color);
+    background-color: var(--orange-tag-bg-color);
+}

--- a/components/ConnectorDetailsHeader/ConnectorDetailsHeader.tsx
+++ b/components/ConnectorDetailsHeader/ConnectorDetailsHeader.tsx
@@ -1,0 +1,54 @@
+import classNames from "classnames";
+import {
+  getConnectorImage,
+  getConnectorPlatformIcon,
+  getStageBadge,
+} from "../../utils/ConnectorsUtils";
+import { ConnectorDetailsHeaderProps } from "./ConnectorDetailsHeader.interface";
+import styles from "./ConnectorDetailsHeader.module.css";
+
+function ConnectorDetailsHeader({
+  name,
+  stage,
+  platform,
+  availableFeatures,
+  unavailableFeatures,
+}: Readonly<ConnectorDetailsHeaderProps>) {
+  return (
+    <div className={styles.Container}>
+      <div className={styles.Heading}>
+        <div className="flex items-center gap-3">
+          <div className={styles.ImageContainer}>{getConnectorImage(name)}</div>
+          <div className={styles.ConnectorName}>{name}</div>
+          {getStageBadge(stage)}
+        </div>
+        <div className={styles.PlatformDetails}>
+          <div>Available In</div>
+          <div className={styles.PlatformIcon}>
+            {getConnectorPlatformIcon(platform)}
+          </div>
+        </div>
+      </div>
+      <div className={styles.SubHeading}>
+        {availableFeatures.map((feature) => (
+          <div
+            className={classNames(styles.FeatureTag, styles.AvailableFeature)}
+            key={feature}
+          >
+            {feature}
+          </div>
+        ))}
+        {unavailableFeatures.map((feature) => (
+          <div
+            className={classNames(styles.FeatureTag, styles.UnavailableFeature)}
+            key={feature}
+          >
+            {feature}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ConnectorDetailsHeader;

--- a/lib/markdoc.ts
+++ b/lib/markdoc.ts
@@ -8,6 +8,7 @@ import CodeInfo from "../components/CodePreview/CodeInfo/CodeInfo";
 import CodeInfoContainer from "../components/CodePreview/CodeInfoContainer/CodeInfoContainer";
 import CodePreview from "../components/CodePreview/CodePreview";
 import CodeWithLanguageSelector from "../components/CodeWithLanguageSelector/CodeWithLanguageSelector";
+import ConnectorDetailsHeader from "../components/ConnectorDetailsHeader/ConnectorDetailsHeader";
 import ConnectorInfoCard from "../components/ConnectorInfoCard/ConnectorInfoCard";
 import ConnectorsListContainer from "../components/ConnectorsListContainer/ConnectorsListContainer";
 import ExtraContent from "../components/ExtraContent/ExtraContent";
@@ -70,6 +71,7 @@ export const components = {
   CodeWithLanguageSelector,
   ConnectorInfoCard,
   ConnectorsListContainer,
+  ConnectorDetailsHeader,
 };
 
 export const configs: Config = {

--- a/markdoc/tags/connectorDetailsHeader.markdoc.ts
+++ b/markdoc/tags/connectorDetailsHeader.markdoc.ts
@@ -1,0 +1,29 @@
+export const connectorDetailsHeader = {
+  render: "ConnectorDetailsHeader",
+  attributes: {
+    name: {
+      type: String,
+      description: "Name of the connector.",
+    },
+    stage: {
+      type: String,
+      description: "The development stage of the connector.",
+      default: "PROD",
+      matches: ["PROD", "BETA"],
+    },
+    platform: {
+      type: String,
+      description: "The platform the connector is available in.",
+      default: "OpenMetadata",
+      matches: ["OpenMetadata", "Collate"],
+    },
+    availableFeatures: {
+      type: Array<string>,
+      description: "List of available features for the connector.",
+    },
+    unavailableFeatures: {
+      type: Array<string>,
+      description: "List of unavailable features for the connector.",
+    },
+  },
+};

--- a/markdoc/tags/index.ts
+++ b/markdoc/tags/index.ts
@@ -15,6 +15,7 @@ export * from "./codePreview/codeInfo.markdoc";
 export * from "./codePreview/codeInfoContainer.markdoc";
 export * from "./codePreview/codePreview.markdoc";
 export * from "./codeWithLanguageSelector/codeWithLanguageSelector.markdoc";
+export * from "./connectorDetailsHeader.markdoc";
 export * from "./connectorInfoCard.markdoc";
 export * from "./connectorsListContainer.markdoc";
 export * from "./divider.markdoc";

--- a/public/globals.css
+++ b/public/globals.css
@@ -47,6 +47,10 @@
   --stable-label-color: #1890ff;
   --stable-label-bg-color: #e6f7ff;
   --connector-icon-bg-color: #F8F8F8;
+  --green-tag-color: #43A047;
+  --green-tag-bg-color: #43A0471A;
+  --orange-tag-color: #FF7C50;
+  --orange-tag-bg-color: #FF7C501A;
 }
 
 body {


### PR DESCRIPTION
feat #194 

I worked on the following:

- [x] Added a new component "ConnectorDetailsHeader" and created a Markdoc tag for the same
- [x] Added the newly added tag details in the README

<img width="1440" alt="Screenshot 2024-02-12 at 5 07 31 PM" src="https://github.com/open-metadata/docs-v1/assets/51777795/94b20a04-595b-473a-a5ad-bec684431ab4">
