### PR TITLE
Minor: Add new connector logos and update homepage connectors list

### DIFF
--- a/components/ConnectorsInfo/ConnectorsInfo.constants.ts
+++ b/components/ConnectorsInfo/ConnectorsInfo.constants.ts
@@ -71,11 +71,6 @@ export const CONNECTORS: Array<ConnectorCategory> = [
         name: "Glue",
       },
       {
-        url: "/connectors/database/datalake",
-        icon: "./images/connectors/googleCloudService.png",
-        name: "GCS",
-      },
-      {
         url: "/connectors/database/greenplum",
         icon: "./images/connectors/greenplum.png",
         name: "Greenplum",
@@ -325,6 +320,28 @@ export const CONNECTORS: Array<ConnectorCategory> = [
         url: "/connectors/search/elasticsearch",
         icon: "./images/connectors/elasticsearch.png",
         name: "Elasticsearch",
+      },
+    ],
+  },
+  {
+    connector: "Storage",
+    services: [
+      {
+        url: "/connectors/storage/adls",
+        icon: "./images/connectors/adls.png",
+        name: "ADLS",
+        supportedVersion: "v1.3.x",
+      },
+      {
+        url: "/connectors/storage/gcs",
+        icon: "./images/connectors/gcs.png",
+        name: "GCS",
+        supportedVersion: "v1.3.x",
+      },
+      {
+        url: "/connectors/storage/s3",
+        icon: "./images/connectors/amazon-s3.png",
+        name: "S3",
       },
     ],
   },

--- a/components/ConnectorsInfo/ConnectorsInfo.tsx
+++ b/components/ConnectorsInfo/ConnectorsInfo.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import { uniqBy } from "lodash";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useState } from "react";
@@ -20,12 +21,12 @@ const ConnectorImage = dynamic(() => import("./ConnectorImage"), {
 CONNECTORS.unshift({
   connector: "All connectors",
   services: CONNECTORS.reduce((prev, curr) => {
-    return [...prev, ...curr.services];
+    return uniqBy([...prev, ...curr.services], "name");
   }, [] as ConnectorCategory["services"]),
 });
 
 export default function ConnectorsInfo() {
-  const { docVersion, onChangeDocVersion } = useDocVersionContext();
+  const { docVersion } = useDocVersionContext();
   const [selectedTab, setSelectedTab] = useState<ConnectorCategory>(
     CONNECTORS[0]
   );

--- a/utils/ConnectorsUtils.tsx
+++ b/utils/ConnectorsUtils.tsx
@@ -67,250 +67,79 @@ export const getConnectorPlatformIcon = (platform: string) => {
 export const getConnectorImage = (connector: string) => {
   let iconSource = "default-service-icon";
 
-  switch (connector) {
-    case "Athena":
-      iconSource = "athena";
-      break;
+  const connectorMappings = {
+    ADLS: "adls",
+    Airbyte: "airbyte",
+    Airflow: "airflow",
+    Alation: "alation",
+    Amundsen: "amundsen",
+    Athena: "athena",
+    Atlas: "atlas",
+    AzureSQL: "azuresql",
+    BigQuery: "bigquery",
+    BigTable: "big-table",
+    Clickhouse: "clickhouse",
+    Collate: "collate",
+    Couchbase: "couchbase",
+    Databricks: "databrick",
+    "Databricks Pipeline": "databrick",
+    "Databricks SQL": "databrick",
+    DB2: "ibmdb2",
+    Dagster: "dagster",
+    Datalake: "amazon-s3",
+    "Delta Lake": "delta-lake",
+    Domo: "domo",
+    "Domo Dashboard": "domo",
+    "Domo Database": "domo",
+    "Domo Pipeline": "domo",
+    Druid: "druid",
+    DynamoDB: "dynamodb",
+    Elasticsearch: "elasticsearch",
+    Fivetran: "fivetran",
+    GCS: "gcs",
+    Glue: "glue",
+    Greenplum: "greenplum",
+    Hive: "hive",
+    Iceberg: "iceberg",
+    Impala: "impala",
+    Kafka: "kafka",
+    Kinesis: "kinesis",
+    Looker: "looker",
+    MariaDB: "mariadb",
+    Metabase: "metabase",
+    MLflow: "mlflow",
+    Mode: "mode",
+    MongoDB: "mongodb",
+    MSSQL: "mssql",
+    MySQL: "sql",
+    NiFi: "apachenifi",
+    Oracle: "oracle",
+    PinotDB: "pinot",
+    Postgres: "post",
+    PowerBI: "power-bi",
+    Presto: "presto",
+    QuickSight: "quicksight",
+    "Qlik Sense": "qlik-sense",
+    Redash: "redash",
+    Redpanda: "redpanda",
+    Redshift: "redshift",
+    Salesforce: "salesforce",
+    "SAP Hana": "sap-hana",
+    SAS: "sas",
+    S3: "amazon-s3",
+    Sagemaker: "sagemaker",
+    SingleStore: "singlestore",
+    Snowflake: "snowflakes",
+    Spline: "spline",
+    SQLite: "sqlite",
+    Superset: "superset",
+    Tableau: "tableau",
+    Trino: "trino",
+    "Unity Catalog": "databrick",
+    Vertica: "vertica",
+  };
 
-    case "Alation":
-      iconSource = "alation";
-      break;
-
-    case "S3":
-    case "Datalake":
-      iconSource = "amazon-s3";
-      break;
-
-    case "AzureSQL":
-      iconSource = "azuresql";
-      break;
-
-    case "BigQuery":
-      iconSource = "bigquery";
-      break;
-
-    case "BigTable":
-      iconSource = "big-table";
-      break;
-
-    case "Clickhouse":
-      iconSource = "clickhouse";
-      break;
-
-    case "Couchbase":
-      iconSource = "couchbase";
-      break;
-
-    case "Databricks":
-    case "Databricks SQL":
-    case "Unity Catalog":
-    case "Databricks Pipeline":
-      iconSource = "databrick";
-      break;
-
-    case "DB2":
-      iconSource = "ibmdb2";
-      break;
-
-    case "Delta Lake":
-      iconSource = "delta-lake";
-      break;
-
-    case "Domo":
-    case "Domo Database":
-    case "Domo Dashboard":
-    case "Domo Pipeline":
-      iconSource = "domo";
-      break;
-
-    case "Druid":
-      iconSource = "druid";
-      break;
-
-    case "DynamoDB":
-      iconSource = "dynamodb";
-      break;
-
-    case "Glue":
-      iconSource = "glue";
-      break;
-
-    case "Greenplum":
-      iconSource = "greenplum";
-      break;
-
-    case "Hive":
-      iconSource = "hive";
-      break;
-
-    case "Iceberg":
-      iconSource = "iceberg";
-      break;
-
-    case "Impala":
-      iconSource = "impala";
-      break;
-
-    case "MariaDB":
-      iconSource = "mariadb";
-      break;
-
-    case "MongoDB":
-      iconSource = "mongodb";
-      break;
-
-    case "MSSQL":
-      iconSource = "mssql";
-      break;
-
-    case "MySQL":
-      iconSource = "sql";
-      break;
-
-    case "Oracle":
-      iconSource = "oracle";
-      break;
-
-    case "PinotDB":
-      iconSource = "pinot";
-      break;
-
-    case "Postgres":
-      iconSource = "post";
-      break;
-
-    case "Presto":
-      iconSource = "presto";
-      break;
-
-    case "Redshift":
-      iconSource = "redshift";
-      break;
-
-    case "Salesforce":
-      iconSource = "salesforce";
-      break;
-
-    case "SAP Hana":
-      iconSource = "sap-hana";
-      break;
-
-    case "SAS":
-      iconSource = "sas";
-      break;
-
-    case "SingleStore":
-      iconSource = "singlestore";
-      break;
-
-    case "Snowflake":
-      iconSource = "snowflakes";
-      break;
-
-    case "SQLite":
-      iconSource = "sqlite";
-      break;
-
-    case "Trino":
-      iconSource = "trino";
-      break;
-
-    case "Vertica":
-      iconSource = "vertica";
-      break;
-
-    case "Looker":
-      iconSource = "looker";
-      break;
-
-    case "Metabase":
-      iconSource = "metabase";
-      break;
-
-    case "Mode":
-      iconSource = "mode";
-      break;
-
-    case "PowerBI":
-      iconSource = "power-bi";
-      break;
-
-    case "Qlik Sense":
-      iconSource = "qlik-sense";
-      break;
-
-    case "QuickSight":
-      iconSource = "quicksight";
-      break;
-
-    case "Redash":
-      iconSource = "redash";
-      break;
-
-    case "Superset":
-      iconSource = "superset";
-      break;
-
-    case "Tableau":
-      iconSource = "tableau";
-      break;
-
-    case "Kafka":
-      iconSource = "kafka";
-      break;
-
-    case "Kinesis":
-      iconSource = "kinesis";
-      break;
-
-    case "Redpanda":
-      iconSource = "redpanda";
-      break;
-
-    case "Airbyte":
-      iconSource = "airbyte";
-      break;
-
-    case "Airflow":
-      iconSource = "airflow";
-      break;
-
-    case "Dagster":
-      iconSource = "dagster";
-      break;
-
-    case "Fivetran":
-      iconSource = "fivetran";
-      break;
-
-    case "NiFi":
-      iconSource = "apachenifi";
-      break;
-
-    case "Spline":
-      iconSource = "spline";
-      break;
-
-    case "MLflow":
-      iconSource = "mlflow";
-      break;
-
-    case "Sagemaker":
-      iconSource = "sagemaker";
-      break;
-
-    case "Amundsen":
-      iconSource = "amundsen";
-      break;
-
-    case "Atlas":
-      iconSource = "atlas";
-      break;
-
-    case "Elasticsearch":
-      iconSource = "elasticsearch";
-      break;
-  }
+  iconSource = connectorMappings[connector] || iconSource;
 
   return (
     <ConnectorImage


### PR DESCRIPTION
- [x] Add newly added `gcs` and `adls` connectors logo mapping
<img width="1150" alt="Screenshot 2024-03-14 at 12 12 01 PM" src="https://github.com/open-metadata/docs-v1/assets/51777795/ff763b32-df66-4e95-9cde-33a841817e06">

- [x] Add missing connectors on homepage connectors list
<img width="1367" alt="Screenshot 2024-03-14 at 12 12 14 PM" src="https://github.com/open-metadata/docs-v1/assets/51777795/6d3ef56e-a158-42e2-860e-9b2035de71a7">
