### PR TITLE
Minor: Update the skip links list

### DIFF
--- a/skip_links.txt
+++ b/skip_links.txt
@@ -6,7 +6,7 @@ https://stackoverflow.com/
 https://twitter.com/open_metadata
 https://oauth2.googleapis.com/
 https://sandbox.open-metadata.org/
-https://cloud.google.com/docs/authentication/
+https://cloud.google.com/
 https://docs.confluent.io/
 http://localhost:9001
 https://java.com/en/download/help/
@@ -25,3 +25,4 @@ https://docs.snowflake.com/
 https://www.microsoft.com/
 https://jaceklaskowski.gitbooks.io/
 https://www.ibm.com/
+https://developers.google.com/


### PR DESCRIPTION
Update the links list of external website page references in the documentation to skip while checking for broken links.