### PR TITLE
Fix connector image fallback and update connector icons

### DIFF
--- a/components/ConnectorsInfo/ConnectorImage.tsx
+++ b/components/ConnectorsInfo/ConnectorImage.tsx
@@ -1,24 +1,34 @@
 import classNames from "classnames";
-import Image, {ImageProps} from "next/image";
-import {ImgHTMLAttributes} from "react";
+import Image, { ImageProps } from "next/image";
+import { useEffect, useMemo, useState } from "react";
 
-const DEFAULT_IMAGE = "./images/connectors/default-service-icon.webp";
+const DEFAULT_IMAGE = "/images/connectors/default-service-icon.webp";
 interface ConnectorImageProps extends ImageProps {
   width?: number;
   height?: number;
 }
-export default function ConnectorImage(props: ConnectorImageProps) {
+export default function ConnectorImage(props: Readonly<ConnectorImageProps>) {
+  // Storing the source of the image in a state to prevent the error event from infinite loop
+  const [src, setSrc] = useState(props.src);
+
   const replaceImgWithError = (e) => {
     e.target.onerror = null;
-    e.target.src = DEFAULT_IMAGE;
+    setSrc(DEFAULT_IMAGE);
   };
-  const {className, ...rest} = props;
+
+  const { className, src: source, ...rest } = useMemo(() => props, [props]);
+
+  useEffect(() => {
+    setSrc(source);
+  }, [source]);
+
   return (
     <Image
       width={32}
       height={32}
       className={classNames("w-8 h-8 object-contain", className)}
       onError={replaceImgWithError}
+      src={src}
       {...rest}
     />
   );

--- a/utils/ConnectorsUtils.tsx
+++ b/utils/ConnectorsUtils.tsx
@@ -1,17 +1,17 @@
 import classNames from "classnames";
-import {sortBy} from "lodash";
+import { sortBy } from "lodash";
 import connectorInfoStyles from "../components/ConnectorInfoCard/ConnectorInfoCard.module.css";
 import ConnectorImage from "../components/ConnectorsInfo/ConnectorImage";
 import {
   ConnectorCategory,
   ConnectorServiceDetails,
 } from "../components/ConnectorsInfo/ConnectorsInfo.interface";
-import {REGEX_TO_EXTRACT_VERSION_NUMBER} from "../constants/version.constants";
-import {ReactComponent as BetaIcon} from "../images/icons/beta-icon.svg";
-import {ReactComponent as CollateIcon} from "../images/icons/ic-collate.svg";
-import {ReactComponent as OpenMetadataIcon} from "../images/icons/om-monogram.svg";
-import {ReactComponent as ProdIcon} from "../images/icons/prod-icon.svg";
-import {getUrlWithVersion} from "./CommonUtils";
+import { REGEX_TO_EXTRACT_VERSION_NUMBER } from "../constants/version.constants";
+import { ReactComponent as BetaIcon } from "../images/icons/beta-icon.svg";
+import { ReactComponent as CollateIcon } from "../images/icons/ic-collate.svg";
+import { ReactComponent as OpenMetadataIcon } from "../images/icons/om-monogram.svg";
+import { ReactComponent as ProdIcon } from "../images/icons/prod-icon.svg";
+import { getUrlWithVersion } from "./CommonUtils";
 
 export const getSortedServiceList = (services: ConnectorCategory["services"]) =>
   sortBy(services, (service) => service.name.toLowerCase());
@@ -103,6 +103,7 @@ export const getConnectorImage = (connector: string) => {
     Iceberg: "iceberg",
     Impala: "impala",
     Kafka: "kafka",
+    KafkaConnect: "kafka",
     Kinesis: "kinesis",
     Looker: "looker",
     MariaDB: "mariadb",


### PR DESCRIPTION
I worked on

- [x] Updating the connectors list to show icons
- [x] Fixing the connector image fallback not showing

**Before:**
<img width="499" alt="Screenshot 2024-04-02 at 2 26 24 PM" src="https://github.com/open-metadata/docs-v1/assets/51777795/879b57b6-f25c-42b5-ba23-54e8bf35e966">

**After:**
<img width="514" alt="Screenshot 2024-04-02 at 2 26 08 PM" src="https://github.com/open-metadata/docs-v1/assets/51777795/65790f4c-c09f-47cb-b773-5fb9763d35a8">
