### PR TITLE
Fix #271: Fix the copy-to-clipboard functionality for codeBlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This is content inside tag.
 
 Here are the custom markdoc tags to use for desired functionalities.
 
+- [Modified Default Nodes](#modified-default-nodes)
+   - [1. fence](#1-fence)
 - [Common Tags](#common-tags)
    - [1. partial](#1-partial)
    - [2. note](#2-note)
@@ -60,6 +62,20 @@ Here are the custom markdoc tags to use for desired functionalities.
    - [2. tile](#2-tile)
 
 ---
+
+## Modified Default Nodes
+
+### 1. fence
+
+The fence node used for multi line code display with indentation has following additional attributes apart from the default markdown attributes.
+
+#### Additional Attributes
+
+1. srNumber (type - String)
+   The code number, to highlight the code when the codeInfo container of the same srNumber is selected.
+
+1. isCodeBlock (type - Boolean)
+   To determine if the code is used inside a 'codeBlock'. Must set true if used inside a 'codeBlock' tag without srNumber. This is essential for the copy to clipboard functionality to work with accurate indentations for the code inside the 'codeBlock'.
 
 ## Common Tags
 
@@ -292,7 +308,7 @@ It's a tag for which will contain explanation or information about a chuck of co
 #### Attributes -
 
 1. srNumber (type - Number)
-   It is the step number and the code chunk number you want to highlight for the given information.
+   It is the code info number and the corresponding code block number you want to highlight for the given information.
    
 **Note: srNumber is also a unique id to identify a code block. Make sure that you have srNumber values unique on a single page. That is even if multiple codePreview components are used in a page, the srNumbers should all be unique and should not repeat on a single page.**
 

--- a/components/common/Code/Code.tsx
+++ b/components/common/Code/Code.tsx
@@ -18,17 +18,37 @@ import "prismjs/plugins/line-highlight/prism-line-highlight.css";
 import "prismjs/plugins/line-numbers/prism-line-numbers";
 import "prismjs/plugins/normalize-whitespace/prism-normalize-whitespace";
 import "prismjs/plugins/toolbar/prism-toolbar";
-import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ReactComponent as ClipboardIcon } from "../../../images/icons/clipboard.svg";
 import Image from "../Image/Image";
 import styles from "./Code.module.css";
 
-export default function Code({ code, children, language, img, srNumber }) {
+export default function Code({
+  code,
+  children,
+  language,
+  img,
+  isCodeBlock = false,
+  srNumber,
+}) {
   const [codeElement, setCodeElement] = useState<JSX.Element>();
   const [copyText, setCopyText] = useState<ReactNode>(
     <ClipboardIcon className={styles.ClipboardIcon} />
   );
   const preTag = useRef<HTMLPreElement>();
+
+  // Consider it as a code block if either srNumber is provided or isCodeBlock is true
+  const isInsideCodeBlock = useMemo(
+    () => srNumber || isCodeBlock,
+    [srNumber, isCodeBlock]
+  );
 
   useEffect(() => {
     if (window) {
@@ -42,7 +62,9 @@ export default function Code({ code, children, language, img, srNumber }) {
   }, [codeElement]);
 
   const getWrappedCodeElement = (codeElement: ReactNode) => {
-    if (srNumber) {
+    if (isInsideCodeBlock) {
+      // No need to wrap it up with <pre> tag if it's inside a code block
+      // Since the code block will be wrapped with <pre> tag
       return codeElement;
     } else {
       return (
@@ -79,39 +101,22 @@ export default function Code({ code, children, language, img, srNumber }) {
       languageClass = children.props.className;
     }
 
-    if (img) {
-      setCodeElement(
-        <div
-          id={srNumber ? `code-block-${srNumber}` : null}
-          className={classNames(
-            `code-container-${language}`,
-            styles.CodeContainer,
-            srNumber ? styles.CodeWithSrNumber : ""
-          )}
-        >
-          <Image src={img} clean={true} />
+    setCodeElement(
+      <div
+        id={srNumber ? `code-block-${srNumber}` : null}
+        className={classNames(
+          `code-container-${language}`,
+          styles.CodeContainer,
+          isInsideCodeBlock ? styles.CodeWithSrNumber : ""
+        )}
+      >
+        {img && <Image src={img} clean={true} />}
 
-          {getWrappedCodeElement(
-            <code className={languageClass}>{customCode}</code>
-          )}
-        </div>
-      );
-    } else {
-      setCodeElement(
-        <div
-          id={srNumber ? `code-block-${srNumber}` : null}
-          className={classNames(
-            `code-container-${language}`,
-            styles.CodeContainer,
-            srNumber ? styles.CodeWithSrNumber : ""
-          )}
-        >
-          {getWrappedCodeElement(
-            <code className={languageClass}>{customCode}</code>
-          )}
-        </div>
-      );
-    }
+        {getWrappedCodeElement(
+          <code className={languageClass}>{customCode}</code>
+        )}
+      </div>
+    );
   }, [img, code, children, language, copyText]);
 
   return codeElement;

--- a/markdoc/nodes/fence.markdoc.ts
+++ b/markdoc/nodes/fence.markdoc.ts
@@ -9,6 +9,14 @@ export const fence = {
     },
     srNumber: {
       type: Number,
+      description:
+        "The code number, to highlight the code when the codeInfo container of the same srNumber is selected.",
+    },
+    isCodeBlock: {
+      type: Boolean,
+      default: false,
+      description:
+        "To determine if the code is used inside a 'codeBlock'. Must set true if used inside a 'codeBlock' tag without srNumber. This is essential for the copy to clipboard functionality to work with accurate indentations for the code inside the 'codeBlock'.",
     },
   },
 };


### PR DESCRIPTION
fixes #271 

I worked on fixing the copy-to-clipboard functionality of the code inside the 'codeBlock' where the correct indentations were not applied.

**Problem Summary:**
Since we were customizing the rendering of the fence node (i.e.  "```" ), we removed the wrapping of the \<code> tag with \<pre> tag for the fences used inside the `codeBlock` tag, to keep single \<pre> tag for all code inside `codeBlock`.

The decision to do so was made by a prop `srNumber` used for the fence inside `codeBlock` but since there were some exceptions where `srNumber` prop was not being used even if used inside `codeBlock`, hence the \<code> tag there was being wrapped in the \<pre> tag again causing the indentation resetting issue

**Solution:**
Added a custom prop to the fence node `isCodeBlock` to indicate the fence used inside the `codeBlock`. Now passing either `isCodeBlock` or the `srNumber` will be considered as fence inside the `codeBlock`.

This will require changes from the content side as well which are taken care of in this [PR](https://github.com/open-metadata/OpenMetadata/pull/16557)