### PR TITLE
MINOR: Change youtube video to 1.4 on home page

### DIFF
--- a/components/common/HomePageBanner/HomePageBanner.tsx
+++ b/components/common/HomePageBanner/HomePageBanner.tsx
@@ -41,7 +41,7 @@ export default function HomePageBanner({
         </div>
       </div>
       <div className={styles.Video}>
-        <YouTube videoId="cVYP1HFXeRM" />
+        <YouTube videoId="oGFWjj_2gM4" />
       </div>
       <div className={styles.BannerNavLinkContainer}>
         {quickLinks.map(


### PR DESCRIPTION
- Change youtube video to 1.4 on home page
<img width="1440" alt="image" src="https://github.com/open-metadata/docs-v1/assets/66266464/e3d32bef-09b6-4f86-9853-41d5cc9fa1b1">
