### PR TITLE
Version and link snapshot improvements

### DIFF
--- a/components/SelectDropdown/SelectDropdown.module.css
+++ b/components/SelectDropdown/SelectDropdown.module.css
@@ -67,7 +67,7 @@
   border-color: var(--beta-label-color);
 }
 
-.StableLabel {
+.LatestLabel {
   color: var(--stable-label-color);
   background: var(--stable-label-bg-color);
   border-color: var(--stable-label-color);

--- a/components/SelectDropdown/SelectDropdown.tsx
+++ b/components/SelectDropdown/SelectDropdown.tsx
@@ -67,14 +67,14 @@ function SelectDropdown<T>({
 
   const getVersionTag = useCallback(
     (option: SelectOption<T>, showStableTag = true) => {
-      if (option.label === STABLE_VERSION && showStableTag) {
+      if (option?.label === STABLE_VERSION && showStableTag) {
         return (
           <span className={classNames(styles.VersionLabel, styles.StableLabel)}>
             Stable
           </span>
         );
       }
-      if (option.label === BETA_VERSION) {
+      if (option?.label === BETA_VERSION) {
         return (
           <span className={classNames(styles.VersionLabel, styles.BetaLabel)}>
             Beta

--- a/components/SelectDropdown/SelectDropdown.tsx
+++ b/components/SelectDropdown/SelectDropdown.tsx
@@ -3,8 +3,10 @@ import { uniqueId } from "lodash";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   BETA_VERSION,
-  STABLE_VERSION,
+  LATEST_VERSION,
 } from "../../constants/version.constants";
+import { useMenuItemsContext } from "../../context/MenuItemsContext";
+import { useRouteChangingContext } from "../../context/RouteChangingContext";
 import { ReactComponent as ArrowDownIcon } from "../../images/icons/arrow-down.svg";
 import { getSelectedOption } from "../../utils/SelectDropdownUtils";
 import styles from "./SelectDropdown.module.css";
@@ -39,7 +41,10 @@ function SelectDropdown<T>({
   const [isDropdownVisible, setIsDropdownVisible] = useState<boolean>(
     isVisible ?? false
   );
+  const isMounting = useRef(true);
   const dropdownContainerRef = useRef<HTMLDivElement>();
+  const { isRouteChanging } = useRouteChangingContext();
+  const { isMenuLoading } = useMenuItemsContext();
 
   const idString = useMemo(() => id ?? uniqueId(), [id]);
 
@@ -65,26 +70,31 @@ function SelectDropdown<T>({
     }
   };
 
-  const getVersionTag = useCallback(
-    (option: SelectOption<T>, showStableTag = true) => {
-      if (option?.label === STABLE_VERSION && showStableTag) {
-        return (
-          <span className={classNames(styles.VersionLabel, styles.StableLabel)}>
-            Stable
-          </span>
-        );
-      }
-      if (option?.label === BETA_VERSION) {
-        return (
-          <span className={classNames(styles.VersionLabel, styles.BetaLabel)}>
-            Beta
-          </span>
-        );
-      }
+  const getVersionTag = useCallback((option: SelectOption<T>) => {
+    if (option?.label === LATEST_VERSION) {
+      return (
+        <span className={classNames(styles.VersionLabel, styles.LatestLabel)}>
+          Latest
+        </span>
+      );
+    }
+    if (option?.label === BETA_VERSION) {
+      return (
+        <span className={classNames(styles.VersionLabel, styles.BetaLabel)}>
+          Beta
+        </span>
+      );
+    }
 
-      return null;
-    },
-    []
+    return null;
+  }, []);
+
+  // To avoid flickering of version tag on initial load
+  // If default value is not in the URL, the tag for the default value should not be shown
+  // till we set the final value from the URL as selected version
+  const showVersionTag = useMemo(
+    () => !isMounting.current && !isRouteChanging && !isMenuLoading,
+    [isMounting.current, isRouteChanging, isMenuLoading]
   );
 
   useEffect(() => {
@@ -101,6 +111,10 @@ function SelectDropdown<T>({
       document.body.removeEventListener("click", handleOutsideClick);
     };
   }, [dropdownContainerRef.current]);
+
+  useEffect(() => {
+    isMounting.current = false;
+  }, []);
 
   return (
     <div
@@ -122,7 +136,7 @@ function SelectDropdown<T>({
             <ArrowDownIcon />
           </span>
         </button>
-        {getVersionTag(selectedOption, false)}
+        {showVersionTag && getVersionTag(selectedOption)}
       </div>
       <div
         className={classNames(

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -7,7 +7,6 @@ import { ReactNode, useCallback, useEffect, useState } from "react";
 import { MdMenu, MdMenuOpen } from "react-icons/md";
 import { InstantSearch } from "react-instantsearch";
 import {
-  DEFAULT_VERSION,
   REGEX_VERSION_MATCH,
   REGEX_VERSION_MATCH_WITH_SLASH_AT_START,
 } from "../../constants/version.constants";
@@ -70,7 +69,7 @@ export default function TopNav({ versionsList, logo }: Readonly<TopNavProps>) {
         onChangeDocVersion(router.query.version);
       } else {
         router.push(
-          `/${DEFAULT_VERSION}${router.asPath.replace(
+          `/latest${router.asPath.replace(
             REGEX_VERSION_MATCH_WITH_SLASH_AT_START,
             ""
           )}`

--- a/components/TrackingPixelScript/TrackingPixelScript.tsx
+++ b/components/TrackingPixelScript/TrackingPixelScript.tsx
@@ -1,0 +1,23 @@
+import Script from "next/script";
+
+function TrackingPixelScript() {
+  return (
+    <Script
+      id="show-banner"
+      dangerouslySetInnerHTML={{
+        __html: `              
+          (function(window, document, dataLayerName, id) {
+            window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
+            function stgCreateCookie(a,b,c){var d="";if(c){var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d="; expires="+e.toUTCString()}document.cookie=a+"="+b+d+"; path=/"}
+            var isStgDebug=(window.location.href.match("stg_debug")||document.cookie.match("stg_debug"))&&!window.location.href.match("stg_disable_debug");stgCreateCookie("stg_debug",isStgDebug?1:"",isStgDebug?14:-1);
+            var qP=[];dataLayerName!=="dataLayer"&&qP.push("data_layer_name="+dataLayerName),isStgDebug&&qP.push("stg_debug");var qPString=qP.length>0?("?"+qP.join("&")):"";
+            tags.async=!0,tags.src="https://collate.containers.piwik.pro/"+id+".js"+qPString,scripts.parentNode.insertBefore(tags,scripts);
+            !function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
+            })(window, document, 'dataLayer', '85b94982-8c42-497f-96c9-353365f1fe7a');
+          `,
+      }}
+    />
+  );
+}
+
+export default TrackingPixelScript;

--- a/constants/version.constants.ts
+++ b/constants/version.constants.ts
@@ -1,7 +1,7 @@
 import { SelectOption } from "../components/SelectDropdown/SelectDropdown";
 
 export const DEFAULT_VERSION = "v1.4.x";
-export const STABLE_VERSION = "v1.4.x";
+export const LATEST_VERSION = "v1.4.x";
 export const BETA_VERSION = "";  // Keep the constant empty when there is no BETA version
 
 export const VERSION_SELECT_DEFAULT_OPTIONS: Array<SelectOption<string>> = [

--- a/constants/version.constants.ts
+++ b/constants/version.constants.ts
@@ -11,7 +11,7 @@ export const VERSION_SELECT_DEFAULT_OPTIONS: Array<SelectOption<string>> = [
   },
 ];
 
-export const REGEX_VERSION_MATCH = /v\d+\.\d+\.x/;
+export const REGEX_VERSION_MATCH = /(v\d+\.\d+\.\w+)|latest/;
 export const REGEX_VERSION_MATCH_WITH_SLASH_AT_START =
-  /^\/v(\d+(\.*[\d\w])*\.*)/g;
+  /^\/((v\d+\.\d+\.\w+)|latest)/g;
 export const REGEX_TO_EXTRACT_VERSION_NUMBER = /\d+\.\d+/;

--- a/content/v1.4.x/how-to-guides/index.md
+++ b/content/v1.4.x/how-to-guides/index.md
@@ -1,6 +1,7 @@
 ---
 title: How-to Guides
 slug: /how-to-guides
+description: Get a complete overview of the features in OpenMetadata from our How-to Guides.
 ---
 
 # How-to Guides

--- a/context/DocVersionContext.tsx
+++ b/context/DocVersionContext.tsx
@@ -4,16 +4,19 @@ import { DEFAULT_VERSION } from "../constants/version.constants";
 export const DocVersionContext = React.createContext({
   docVersion: DEFAULT_VERSION,
   onChangeDocVersion: (version: string) => null,
-  enableVersion: true
+  enableVersion: true,
 });
 
 export const useDocVersionContext = () => useContext(DocVersionContext);
 
-export const DocVersionContextProvider = ({ children, enableVersion = true }) => {
+export const DocVersionContextProvider = ({
+  children,
+  enableVersion = true,
+}) => {
   const [docVersion, setDocVersion] = useState(DEFAULT_VERSION);
 
   const onChangeDocVersion = (version: string) => {
-    setDocVersion(version);
+    setDocVersion(version === "latest" ? DEFAULT_VERSION : version);
   };
 
   const contextValue = useMemo(

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,11 +1,16 @@
 import fs from "fs";
+import { sortBy } from "lodash";
 import { join } from "path";
 import slugify from "slugify";
 import {
   ARTICLES_DIRECTORY,
   PARTIALS_DIRECTORY,
 } from "../constants/common.constants";
-import { REGEX_VERSION_MATCH, VERSION_SELECT_DEFAULT_OPTIONS } from "./../constants/version.constants";
+import {
+  DEFAULT_VERSION,
+  REGEX_VERSION_MATCH,
+  VERSION_SELECT_DEFAULT_OPTIONS,
+} from "./../constants/version.constants";
 
 export function getAllFilesInDirectory(
   articleDirectory: string,
@@ -40,13 +45,12 @@ export const getVersionsList = () => {
       .filter((version) => REGEX_VERSION_MATCH.test(version))
       .map((version) => ({
         label: version,
-        value: version,
+        value: version === DEFAULT_VERSION ? "latest" : version,
       }));
 
-    versionsList.sort();
-    versionsList.reverse();
+    const sortedVersion = sortBy(versionsList, "label").reverse();
 
-    return versionsList;
+    return sortedVersion;
   } catch (error) {
     return VERSION_SELECT_DEFAULT_OPTIONS;
   }

--- a/pages/[version]/[...slug].tsx
+++ b/pages/[version]/[...slug].tsx
@@ -75,6 +75,7 @@ export default function Article({
     <>
       <Head>
         <title>{pageTitle}</title>
+        <meta content={pageTitle} property="og:title" />
         <meta content={pageTitle} name="twitter:title" />
         {pageDescription && (
           <React.Fragment>

--- a/pages/[version]/[...slug].tsx
+++ b/pages/[version]/[...slug].tsx
@@ -1,33 +1,36 @@
 import Markdoc from "@markdoc/markdoc";
-import fs from "fs";
-import matter from "gray-matter";
-import { isEqual, isObject } from "lodash";
+import { isEqual, isObject, isUndefined } from "lodash";
+import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
+import Head from "next/head";
 import Script from "next/script";
-import { basename } from "path";
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import ErrorBoundary from "../../components/ErrorBoundary";
+import Footer from "../../components/Footer/Footer";
 import GoogleAnalyticsScript from "../../components/GoogleAnalyticsScript/GoogleAnalyticsScript";
 import APIPageLayout from "../../components/PageLayouts/APIPageLayout/APIPageLayout";
 import DocsPageLayout from "../../components/PageLayouts/DocsPageLayout/DocsPageLayout";
 import { SelectOption } from "../../components/SelectDropdown/SelectDropdown";
+import TopNav from "../../components/TopNav/TopNav";
 import { API_AND_SDK_MENU_ITEMS } from "../../constants/categoriesNav.constants";
-import { PathObj } from "../../interface/common.interface";
 import {
-  getArticleSlugFromString,
-  getArticleSlugs,
-  getPartialsConfigObject,
-  getVersionsList,
-} from "../../lib/api";
+  DEFAULT_VERSION,
+  REGEX_VERSION_MATCH,
+} from "../../constants/version.constants";
+import { getVersionsList } from "../../lib/api";
 import { configs } from "../../lib/markdoc";
 import { getFormattedPartials } from "../../utils/CommonUtils";
-import Footer from "../../components/Footer/Footer";
-import TopNav from "../../components/TopNav/TopNav";
+import {
+  getPaths,
+  getReturnObjectForValidVersion,
+} from "../../utils/SlugUtils";
 
-interface Props {
+export interface SlugProps {
   content: string;
   slug: string[];
   versionsList: Array<SelectOption<string>>;
   partials: Record<string, string>;
+  pageTitle: string;
+  pageDescription: string;
 }
 
 export default function Article({
@@ -35,7 +38,9 @@ export default function Article({
   slug,
   versionsList,
   partials,
-}: Readonly<Props>) {
+  pageTitle,
+  pageDescription,
+}: Readonly<SlugProps>) {
   const ast = useMemo(() => Markdoc.parse(content), [content]);
 
   const formattedPartialsObj = useMemo(
@@ -68,10 +73,20 @@ export default function Article({
 
   return (
     <>
-      <Script
-        id="show-banner"
-        dangerouslySetInnerHTML={{
-          __html: `              
+      <Head>
+        <title>{pageTitle}</title>
+        <meta content={pageTitle} name="twitter:title" />
+        {pageDescription && (
+          <React.Fragment>
+            <meta content={pageDescription} name="description" />
+            <meta content={pageDescription} property="og:description" />
+            <meta content={pageDescription} name="twitter:description" />
+          </React.Fragment>
+        )}
+        <Script
+          id="show-banner"
+          dangerouslySetInnerHTML={{
+            __html: `              
                 (function(window, document, dataLayerName, id) {
                   window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
                   function stgCreateCookie(a,b,c){var d="";if(c){var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d="; expires="+e.toUTCString()}document.cookie=a+"="+b+d+"; path=/"}
@@ -81,9 +96,11 @@ export default function Article({
                   !function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
                   })(window, document, 'dataLayer', '85b94982-8c42-497f-96c9-353365f1fe7a');
                 `,
-        }}
-      />
-      <GoogleAnalyticsScript />
+          }}
+        />
+        <GoogleAnalyticsScript />
+      </Head>
+
       <ErrorBoundary>
         {isAPIsPage.value ? (
           <APIPageLayout
@@ -103,48 +120,52 @@ export default function Article({
   );
 }
 
-export async function getServerSideProps(context) {
+export async function getServerSideProps(
+  context: GetServerSidePropsContext
+): Promise<GetServerSidePropsResult<SlugProps>> {
   try {
+    const version = context.params.version as string;
+    const slug = context.params.slug as string[];
+    const pathWithoutVersion = slug.join("/");
+
+    // If the version in the URL is the default version, change the path to /latest
+    if (version === DEFAULT_VERSION) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: `/latest/${pathWithoutVersion}`,
+        },
+      };
+    }
+
+    // Get all paths for the docs
     const paths = await getPaths();
-    const props = { menu: [], content: "", slug: [] };
+
+    // Default props
+    const props: SlugProps = {
+      content: "",
+      slug: [],
+      versionsList: [],
+      partials: {},
+      pageTitle: "",
+      pageDescription: "",
+    };
 
     // Check if the version field passed in context params is proper version format
-    const versionFormat = /v\d+\.\d+\.x/;
-    const isVersionPresent = versionFormat.test(context.params.version);
+    const isVersionValid = REGEX_VERSION_MATCH.test(version);
 
     const versionsList: Array<SelectOption<string>> = getVersionsList();
 
-    if (isVersionPresent) {
-      let location = `/${context.params.version}/${context.params.slug.join(
-        "/"
-      )}`;
+    // Handle the case when the version is valid
+    if (isVersionValid) {
+      const returnObj = getReturnObjectForValidVersion({
+        context,
+        paths,
+        versionsList,
+      });
 
-      const partials = getPartialsConfigObject();
-
-      if ("slug" in context.params) {
-        let filename = "";
-        let notFound = true;
-
-        for (const obj of paths) {
-          if (`/${obj.params.version}${obj.params.location}` === location) {
-            filename = obj.params.fileName;
-            notFound = false;
-            break;
-          }
-        }
-
-        if (notFound) {
-          return { notFound };
-        }
-
-        // Get the last element of the array to find the MD file
-        const fileContents = fs.readFileSync(filename, "utf8");
-        const { content } = matter(fileContents);
-
-        props["content"] = content;
-        props["slug"] = context.params.slug;
-        props["versionsList"] = versionsList;
-        props["partials"] = partials;
+      if (!isUndefined(returnObj)) {
+        return returnObj;
       }
     }
 
@@ -154,49 +175,4 @@ export async function getServerSideProps(context) {
       notFound: true,
     };
   }
-}
-
-async function getPaths() {
-  // Build up paths based on slugified categories for all docs
-  const articles = getArticleSlugs();
-  const paths: PathObj[] = [];
-
-  // Load each file and map a path
-
-  for (const index in articles) {
-    let slug = basename(articles[index]).replace(/\.md$/, "");
-    let realSlug = [slug];
-    slug = `/${slug}`;
-    const fileContents = fs.readFileSync(articles[index], "utf8");
-    const { data } = matter(fileContents);
-
-    // Use slug instead of Category if it's present
-    if ("slug" in data) {
-      slug = data.slug;
-      realSlug = data.slug.split("/").map(getArticleSlugFromString);
-      realSlug.shift();
-    }
-
-    const slugsArray = articles[index].split("/");
-
-    const versionIndex =
-      slugsArray.findIndex((slugString) => slugString === "content") + 1;
-
-    const version = slugsArray[versionIndex];
-
-    let path = {
-      params: {
-        slug: realSlug,
-        location: slug,
-        version: version,
-        fileName: articles[index],
-        title: data.title ? (data.title as string) : "Untitled",
-        description: data.description ? (data.description as string) : "",
-      },
-    };
-
-    paths.push(path);
-  }
-
-  return paths;
 }

--- a/pages/[version]/[...slug].tsx
+++ b/pages/[version]/[...slug].tsx
@@ -1,12 +1,8 @@
 import Markdoc from "@markdoc/markdoc";
 import { isEqual, isObject, isUndefined } from "lodash";
 import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
-import Head from "next/head";
-import Script from "next/script";
-import React, { useMemo } from "react";
-import ErrorBoundary from "../../components/ErrorBoundary";
+import { useMemo } from "react";
 import Footer from "../../components/Footer/Footer";
-import GoogleAnalyticsScript from "../../components/GoogleAnalyticsScript/GoogleAnalyticsScript";
 import APIPageLayout from "../../components/PageLayouts/APIPageLayout/APIPageLayout";
 import DocsPageLayout from "../../components/PageLayouts/DocsPageLayout/DocsPageLayout";
 import { SelectOption } from "../../components/SelectDropdown/SelectDropdown";
@@ -71,53 +67,18 @@ export default function Article({
       : { value: false, pageInfoObject: { label: "", value: "" } };
   }, [slug]);
 
-  return (
-    <>
-      <Head>
-        <title>{pageTitle}</title>
-        <meta content={pageTitle} property="og:title" />
-        <meta content={pageTitle} name="twitter:title" />
-        {pageDescription && (
-          <React.Fragment>
-            <meta content={pageDescription} name="description" />
-            <meta content={pageDescription} property="og:description" />
-            <meta content={pageDescription} name="twitter:description" />
-          </React.Fragment>
-        )}
-        <Script
-          id="show-banner"
-          dangerouslySetInnerHTML={{
-            __html: `              
-                (function(window, document, dataLayerName, id) {
-                  window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
-                  function stgCreateCookie(a,b,c){var d="";if(c){var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d="; expires="+e.toUTCString()}document.cookie=a+"="+b+d+"; path=/"}
-                  var isStgDebug=(window.location.href.match("stg_debug")||document.cookie.match("stg_debug"))&&!window.location.href.match("stg_disable_debug");stgCreateCookie("stg_debug",isStgDebug?1:"",isStgDebug?14:-1);
-                  var qP=[];dataLayerName!=="dataLayer"&&qP.push("data_layer_name="+dataLayerName),isStgDebug&&qP.push("stg_debug");var qPString=qP.length>0?("?"+qP.join("&")):"";
-                  tags.async=!0,tags.src="https://collate.containers.piwik.pro/"+id+".js"+qPString,scripts.parentNode.insertBefore(tags,scripts);
-                  !function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
-                  })(window, document, 'dataLayer', '85b94982-8c42-497f-96c9-353365f1fe7a');
-                `,
-          }}
-        />
-        <GoogleAnalyticsScript />
-      </Head>
-
-      <ErrorBoundary>
-        {isAPIsPage.value ? (
-          <APIPageLayout
-            parsedContent={parsedContent}
-            pageInfoObject={isAPIsPage.pageInfoObject}
-          />
-        ) : (
-          <DocsPageLayout
-            navbar={<TopNav versionsList={versionsList} />}
-            parsedContent={parsedContent}
-            slug={slug}
-            footer={<Footer />}
-          />
-        )}
-      </ErrorBoundary>
-    </>
+  return isAPIsPage.value ? (
+    <APIPageLayout
+      parsedContent={parsedContent}
+      pageInfoObject={isAPIsPage.pageInfoObject}
+    />
+  ) : (
+    <DocsPageLayout
+      navbar={<TopNav versionsList={versionsList} />}
+      parsedContent={parsedContent}
+      slug={slug}
+      footer={<Footer />}
+    />
   );
 }
 

--- a/pages/[version]/index.tsx
+++ b/pages/[version]/index.tsx
@@ -1,9 +1,7 @@
-import Head from "next/head";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import CategoriesNav from "../../components/CategoriesNav/CategoriesNav";
 import ConnectorsInfo from "../../components/ConnectorsInfo/ConnectorsInfo";
 import Footer from "../../components/Footer/Footer";
-import GoogleAnalyticsScript from "../../components/GoogleAnalyticsScript/GoogleAnalyticsScript";
 import NewsEntry from "../../components/NewsEntry/NewsEntry";
 import { SelectOption } from "../../components/SelectDropdown/SelectDropdown";
 import TopNav from "../../components/TopNav/TopNav";
@@ -23,10 +21,6 @@ import { useRouteChangingContext } from "../../context/RouteChangingContext";
 import { SkeletonWidth } from "../../enums/SkeletonLoder.enum";
 import { getVersionsList } from "../../lib/api";
 
-const TITLE = "OpenMetadata Documentation: Get Help Instantly";
-const DESCRIPTION =
-  "Follow the step-by-step guides to get started with OpenMetadata, the #1 open source data catalog tool. Get discovery, collaboration, governance, observability, quality tools all in one place.";
-
 interface Props {
   versionsList: Array<SelectOption<string>>;
 }
@@ -44,19 +38,6 @@ export default function Index({ versionsList }: Readonly<Props>) {
 
   return (
     <>
-      <Head>
-        <title>{TITLE}</title>
-        <meta content={TITLE} property="og:title" />
-        <meta content={TITLE} name="twitter:title" />
-        {DESCRIPTION && (
-          <React.Fragment>
-            <meta content={DESCRIPTION} name="description" />
-            <meta content={DESCRIPTION} property="og:description" />
-            <meta content={DESCRIPTION} name="twitter:description" />
-          </React.Fragment>
-        )}
-        <GoogleAnalyticsScript />
-      </Head>
       <div className="nav-bar-container">
         <TopNav versionsList={versionsList} />
         <CategoriesNav menu={menuItems} />

--- a/pages/[version]/index.tsx
+++ b/pages/[version]/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import Head from "next/head";
+import React, { useEffect } from "react";
 import CategoriesNav from "../../components/CategoriesNav/CategoriesNav";
 import ConnectorsInfo from "../../components/ConnectorsInfo/ConnectorsInfo";
 import Footer from "../../components/Footer/Footer";
@@ -16,12 +17,15 @@ import {
   OVERVIEW_INFO,
   QUICK_LINK_CARDS,
 } from "../../constants/homePage.constants";
-import { useDocVersionContext } from "../../context/DocVersionContext";
 import { useMenuItemsContext } from "../../context/MenuItemsContext";
 import { useNavBarCollapsedContext } from "../../context/NavBarCollapseContext";
 import { useRouteChangingContext } from "../../context/RouteChangingContext";
 import { SkeletonWidth } from "../../enums/SkeletonLoder.enum";
 import { getVersionsList } from "../../lib/api";
+
+const TITLE = "OpenMetadata Documentation: Get Help Instantly";
+const DESCRIPTION =
+  "Follow the step-by-step guides to get started with OpenMetadata, the #1 open source data catalog tool. Get discovery, collaboration, governance, observability, quality tools all in one place.";
 
 interface Props {
   versionsList: Array<SelectOption<string>>;
@@ -29,7 +33,6 @@ interface Props {
 
 export default function Index({ versionsList }: Readonly<Props>) {
   const { isRouteChanging } = useRouteChangingContext();
-  const { docVersion } = useDocVersionContext();
   const { isMobileDevice } = useNavBarCollapsedContext();
   const { menuItems } = useMenuItemsContext();
 
@@ -41,7 +44,19 @@ export default function Index({ versionsList }: Readonly<Props>) {
 
   return (
     <>
-      <GoogleAnalyticsScript />
+      <Head>
+        <title>{TITLE}</title>
+        <meta content={TITLE} property="og:title" />
+        <meta content={TITLE} name="twitter:title" />
+        {DESCRIPTION && (
+          <React.Fragment>
+            <meta content={DESCRIPTION} name="description" />
+            <meta content={DESCRIPTION} property="og:description" />
+            <meta content={DESCRIPTION} name="twitter:description" />
+          </React.Fragment>
+        )}
+        <GoogleAnalyticsScript />
+      </Head>
       <div className="nav-bar-container">
         <TopNav versionsList={versionsList} />
         <CategoriesNav menu={menuItems} />
@@ -85,7 +100,10 @@ export default function Index({ versionsList }: Readonly<Props>) {
             </div>
             <div className="homepage-containers">
               <div className="container-heading">Connectors</div>
-              <ConnectorsInfo tabStyle="connector-tab" activeTabStyle="active-connector" />
+              <ConnectorsInfo
+                tabStyle="connector-tab"
+                activeTabStyle="active-connector"
+              />
             </div>
             <div className="homepage-containers">
               <div className="container-heading">Blogs</div>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,23 +5,39 @@ import "prismjs";
 import "../public/globals.css";
 import "../public/modal.css";
 
-import type { MarkdocNextJsPageProps } from "@markdoc/next.js";
+import { isEmpty } from "lodash";
 import type { AppProps } from "next/app";
 import ErrorBoundary from "../components/ErrorBoundary";
+import GoogleAnalyticsScript from "../components/GoogleAnalyticsScript/GoogleAnalyticsScript";
 import { RunLLMWidgetScript } from "../components/RunLLMWidgetScript/RunLLMWidgetScript";
+import TrackingPixelScript from "../components/TrackingPixelScript/TrackingPixelScript";
 import { CodeWithLanguageSelectorContextProvider } from "../context/CodeWithLanguageSelectorContext";
 import { DocVersionContextProvider } from "../context/DocVersionContext";
 import { MenuItemsContextProvider } from "../context/MenuItemsContext";
 import { NavBarCollapseContextProvider } from "../context/NavBarCollapseContext";
 import { RouteChangingContextProvider } from "../context/RouteChangingContext";
 import { StepsContextProvider } from "../context/StepsContext";
+import { SlugProps } from "./[version]/[...slug]";
 
-export type MyAppProps = MarkdocNextJsPageProps;
+const TITLE = "OpenMetadata Documentation: Get Help Instantly";
+const DESCRIPTION =
+  "Follow the step-by-step guides to get started with OpenMetadata, the #1 open source data catalog tool. Get discovery, collaboration, governance, observability, quality tools all in one place.";
 
-export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
+export default function MyApp({ Component, pageProps }: AppProps<SlugProps>) {
+  const title = isEmpty(pageProps.pageTitle) ? TITLE : pageProps.pageTitle;
+  const description = isEmpty(pageProps.pageDescription)
+    ? DESCRIPTION
+    : pageProps.pageDescription;
+
   return (
     <>
       <Head>
+        <title>{title}</title>
+        <meta property="og:title" content={title} />
+        <meta name="twitter:title" content={title} />
+        <meta name="description" content={description} />
+        <meta property="og:description" content={description} />
+        <meta name="twitter:description" content={description} />
         <link rel="icon" href="/favicon.png" />
         <link rel="alternate icon" href="/favicon.png" />
         <link rel="shortcut icon" href="/favicon180.png" />
@@ -32,8 +48,10 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
         />
         <meta property="og:type" content="website" />
         <meta content="summary_large_image" name="twitter:card" />
-        <RunLLMWidgetScript />
       </Head>
+      <RunLLMWidgetScript />
+      <GoogleAnalyticsScript />
+      <TrackingPixelScript />
       <ErrorBoundary>
         <RouteChangingContextProvider>
           <DocVersionContextProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,13 +9,13 @@ import "../public/modal.css";
 import type { MarkdocNextJsPageProps } from "@markdoc/next.js";
 import type { AppProps } from "next/app";
 import ErrorBoundary from "../components/ErrorBoundary";
+import { RunLLMWidgetScript } from "../components/RunLLMWidgetScript/RunLLMWidgetScript";
 import { CodeWithLanguageSelectorContextProvider } from "../context/CodeWithLanguageSelectorContext";
 import { DocVersionContextProvider } from "../context/DocVersionContext";
 import { MenuItemsContextProvider } from "../context/MenuItemsContext";
 import { NavBarCollapseContextProvider } from "../context/NavBarCollapseContext";
 import { RouteChangingContextProvider } from "../context/RouteChangingContext";
 import { StepsContextProvider } from "../context/StepsContext";
-import { RunLLMWidgetScript } from "../components/RunLLMWidgetScript/RunLLMWidgetScript";
 
 const TITLE = "OpenMetadata Documentation: Get Help Instantly";
 const DESCRIPTION =
@@ -32,8 +32,8 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
         <link rel="alternate icon" href="/favicon.png" />
         <link rel="shortcut icon" href="/favicon180.png" />
         <meta name="theme-color" content="#ffffff" />
-        <meta content="OpenMetadata Docs" property="og:title" />
-        <meta content="OpenMetadata Docs" name="twitter:title" />
+        <meta content={TITLE} property="og:title" />
+        <meta content={TITLE} name="twitter:title" />
         <meta
           name="keywords"
           content="best open-source data catalog, #1 open source data catalog, openmetadata documentation, data governance solutions, centralized metadata platform, best data discovery tool, data collaboration platform, modern data catalog, data catalog data lineage, best metadata management tool"
@@ -48,12 +48,6 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
         <meta property="og:type" content="website" />
         <meta content="summary_large_image" name="twitter:card" />
         <RunLLMWidgetScript />
-        {/* Temporarily commenting out the GiffyGPT code as it is giving 404 */}
-        {/* <script
-          src="https://jiffygpt.com/embed.js"
-          id={process.env.NEXT_PUBLIC_GIFFY_GPT_ID}
-          defer
-        ></script> */}
       </Head>
       <ErrorBoundary>
         <RouteChangingContextProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,4 @@
 import Head from "next/head";
-import React from "react";
 
 import "prismjs";
 // Import other Prism themes here
@@ -17,34 +16,20 @@ import { NavBarCollapseContextProvider } from "../context/NavBarCollapseContext"
 import { RouteChangingContextProvider } from "../context/RouteChangingContext";
 import { StepsContextProvider } from "../context/StepsContext";
 
-const TITLE = "OpenMetadata Documentation: Get Help Instantly";
-const DESCRIPTION =
-  "Follow the step-by-step guides to get started with OpenMetadata, the #1 open source data catalog tool. Get discovery, collaboration, governance, observability, quality tools all in one place.";
-
 export type MyAppProps = MarkdocNextJsPageProps;
 
 export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
   return (
     <>
       <Head>
-        <title>{TITLE}</title>
         <link rel="icon" href="/favicon.png" />
         <link rel="alternate icon" href="/favicon.png" />
         <link rel="shortcut icon" href="/favicon180.png" />
         <meta name="theme-color" content="#ffffff" />
-        <meta content={TITLE} property="og:title" />
-        <meta content={TITLE} name="twitter:title" />
         <meta
           name="keywords"
           content="best open-source data catalog, #1 open source data catalog, openmetadata documentation, data governance solutions, centralized metadata platform, best data discovery tool, data collaboration platform, modern data catalog, data catalog data lineage, best metadata management tool"
         />
-        {DESCRIPTION && (
-          <React.Fragment>
-            <meta content={DESCRIPTION} name="description" />
-            <meta content={DESCRIPTION} property="og:description" />
-            <meta content={DESCRIPTION} name="twitter:description" />
-          </React.Fragment>
-        )}
         <meta property="og:type" content="website" />
         <meta content="summary_large_image" name="twitter:card" />
         <RunLLMWidgetScript />

--- a/pages/api/getVersionsList.ts
+++ b/pages/api/getVersionsList.ts
@@ -1,17 +1,28 @@
 import fs from "fs";
 import { ARTICLES_DIRECTORY } from "../../constants/common.constants";
+import {
+  DEFAULT_VERSION,
+  REGEX_VERSION_MATCH,
+} from "../../constants/version.constants";
 
 // API to get versions list from the content folder
 
 export default function handler(req, res) {
   try {
     const versionsArray = fs.readdirSync(ARTICLES_DIRECTORY);
-    const versionOptionsObj = versionsArray.map((version) => ({
-      label: version,
-      value: version,
-    }));
+    const versionsList = versionsArray
+      // content folder now also has other folders like partial or the next release snapshot content with the versions folders
+      // this check is to select only versions folders
+      .filter((version) => REGEX_VERSION_MATCH.test(version))
+      .map((version) => ({
+        label: version,
+        value: version === DEFAULT_VERSION ? "latest" : version,
+      }));
 
-    res.status(200).json(versionOptionsObj);
+    versionsList.sort();
+    versionsList.reverse();
+
+    res.status(200).json(versionsList);
   } catch (err) {
     res.status(err.code === "ENOENT" ? 404 : 400).send(err);
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,7 @@
-import Head from "next/head";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import CategoriesNav from "../components/CategoriesNav/CategoriesNav";
 import ConnectorsInfo from "../components/ConnectorsInfo/ConnectorsInfo";
 import Footer from "../components/Footer/Footer";
-import GoogleAnalyticsScript from "../components/GoogleAnalyticsScript/GoogleAnalyticsScript";
 import NewsEntry from "../components/NewsEntry/NewsEntry";
 import { SelectOption } from "../components/SelectDropdown/SelectDropdown";
 import TopNav from "../components/TopNav/TopNav";
@@ -56,19 +54,6 @@ export default function Index({ versionsList }: Readonly<Props>) {
 
   return (
     <>
-      <Head>
-        <title>{TITLE}</title>
-        <meta content={TITLE} property="og:title" />
-        <meta content={TITLE} name="twitter:title" />
-        {DESCRIPTION && (
-          <React.Fragment>
-            <meta content={DESCRIPTION} name="description" />
-            <meta content={DESCRIPTION} property="og:description" />
-            <meta content={DESCRIPTION} name="twitter:description" />
-          </React.Fragment>
-        )}
-        <GoogleAnalyticsScript />
-      </Head>
       <div className="nav-bar-container">
         <TopNav versionsList={versionsList} />
         <CategoriesNav menu={menu} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import Head from "next/head";
+import React, { useEffect, useState } from "react";
 import CategoriesNav from "../components/CategoriesNav/CategoriesNav";
 import ConnectorsInfo from "../components/ConnectorsInfo/ConnectorsInfo";
 import Footer from "../components/Footer/Footer";
@@ -23,7 +24,10 @@ import { SkeletonWidth } from "../enums/SkeletonLoder.enum";
 import { MenuItem } from "../interface/common.interface";
 import { getVersionsList } from "../lib/api";
 import { fetchMenuList } from "../utils/CommonUtils";
-import RunLLMWidgetScript from "../components/RunLLMWidgetScript/RunLLMWidgetScript";
+
+const TITLE = "OpenMetadata Documentation: Get Help Instantly";
+const DESCRIPTION =
+  "Follow the step-by-step guides to get started with OpenMetadata, the #1 open source data catalog tool. Get discovery, collaboration, governance, observability, quality tools all in one place.";
 
 interface Props {
   versionsList: Array<SelectOption<string>>;
@@ -52,8 +56,19 @@ export default function Index({ versionsList }: Readonly<Props>) {
 
   return (
     <>
-      <GoogleAnalyticsScript />
-      <RunLLMWidgetScript />
+      <Head>
+        <title>{TITLE}</title>
+        <meta content={TITLE} property="og:title" />
+        <meta content={TITLE} name="twitter:title" />
+        {DESCRIPTION && (
+          <React.Fragment>
+            <meta content={DESCRIPTION} name="description" />
+            <meta content={DESCRIPTION} property="og:description" />
+            <meta content={DESCRIPTION} name="twitter:description" />
+          </React.Fragment>
+        )}
+        <GoogleAnalyticsScript />
+      </Head>
       <div className="nav-bar-container">
         <TopNav versionsList={versionsList} />
         <CategoriesNav menu={menu} />
@@ -97,7 +112,10 @@ export default function Index({ versionsList }: Readonly<Props>) {
             </div>
             <div className="homepage-containers">
               <div className="container-heading">Connectors</div>
-              <ConnectorsInfo tabStyle="connector-tab" activeTabStyle="active-connector" />
+              <ConnectorsInfo
+                tabStyle="connector-tab"
+                activeTabStyle="active-connector"
+              />
             </div>
             <div className="homepage-containers">
               <div className="container-heading">Blogs</div>

--- a/utils/CommonUtils.ts
+++ b/utils/CommonUtils.ts
@@ -14,7 +14,7 @@ export const generateIdFromHeading = (heading: string) => {
 };
 
 export const getUrlWithVersion = (url: string, docVersion: string) => {
-  return `/${docVersion}${url}`;
+  return `/${docVersion === DEFAULT_VERSION ? "latest" : docVersion}${url}`;
 };
 
 export const getUrl = ({

--- a/utils/SelectDropdownUtils.ts
+++ b/utils/SelectDropdownUtils.ts
@@ -4,6 +4,7 @@ export function getSelectedOption<T>(
   options: Array<SelectOption<T>>,
   value: T
 ): SelectOption<T> {
-  const selectedOptions = options.find((option) => option.value === value);
+  // Using label to compare here instead of value since the value may contain 'latest' text
+  const selectedOptions = options.find((option) => option.label === value);
   return selectedOptions;
 }

--- a/utils/SlugUtils.ts
+++ b/utils/SlugUtils.ts
@@ -1,0 +1,127 @@
+import fs from "fs";
+import matter from "gray-matter";
+import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
+import { basename } from "path";
+import { SelectOption } from "../components/SelectDropdown/SelectDropdown";
+import { DEFAULT_VERSION } from "../constants/version.constants";
+import { PathObj } from "../interface/common.interface";
+import {
+  getArticleSlugFromString,
+  getArticleSlugs,
+  getPartialsConfigObject,
+} from "../lib/api";
+import { SlugProps } from "../pages/[version]/[...slug]";
+
+export async function getPaths() {
+  // Build up paths based on slugified categories for all docs
+  const articles = getArticleSlugs();
+  const paths: PathObj[] = [];
+
+  // Load each file and map a path
+
+  for (const index in articles) {
+    let slug = basename(articles[index]).replace(/\.md$/, "");
+    let realSlug = [slug];
+    slug = `/${slug}`;
+    const fileContents = fs.readFileSync(articles[index], "utf8");
+    const { data } = matter(fileContents);
+
+    // Use slug instead of Category if it's present
+    if ("slug" in data) {
+      slug = data.slug;
+      realSlug = data.slug.split("/").map(getArticleSlugFromString);
+      realSlug.shift();
+    }
+
+    const slugsArray = articles[index].split("/");
+
+    const versionIndex =
+      slugsArray.findIndex((slugString) => slugString === "content") + 1;
+
+    const version = slugsArray[versionIndex];
+
+    let path = {
+      params: {
+        slug: realSlug,
+        location: slug,
+        version: version,
+        fileName: articles[index],
+        title: data.title ? (data.title as string) : "Untitled",
+        description: data.description ? (data.description as string) : "",
+      },
+    };
+
+    paths.push(path);
+  }
+
+  return paths;
+}
+
+export const getReturnObjectForValidVersion = ({
+  context,
+  paths,
+  versionsList,
+}: {
+  context: GetServerSidePropsContext;
+  paths: PathObj[];
+  versionsList: SelectOption<string>[];
+}): GetServerSidePropsResult<SlugProps> => {
+  const version = context.params.version as string;
+  const slug = context.params.slug as string[];
+  const pathWithoutVersion = slug.join("/");
+  const versionNumber = version === "latest" ? DEFAULT_VERSION : version;
+
+  let location = `/${versionNumber}/${pathWithoutVersion}`;
+
+  const partials = getPartialsConfigObject();
+
+  if ("slug" in context.params) {
+    let filename = "";
+    let notFound = true;
+
+    for (const obj of paths) {
+      if (`/${obj.params.version}${obj.params.location}` === location) {
+        filename = obj.params.fileName;
+        notFound = false;
+        break;
+      }
+    }
+
+    // If the file is not found in the content folder
+    if (notFound) {
+      // Check if the version is present in the existing versions list
+      const isVersionPresent = versionsList.some(
+        (versionOption) => versionOption.value === version
+      );
+
+      // If the version is present in versions list, return 404
+      if (isVersionPresent) {
+        return { notFound };
+      }
+
+      // If the version is not present in versions list, redirect to the latest version
+      // Instead of showing 404
+      return {
+        redirect: {
+          permanent: false,
+          destination: `/latest/${pathWithoutVersion}`,
+        },
+      };
+    }
+
+    // Get the last element of the array to find the MD file
+    const fileContents = fs.readFileSync(filename, "utf8");
+    const { content, data } = matter(fileContents);
+
+    return {
+      props: {
+        content,
+        slug,
+        versionsList,
+        partials,
+        pageTitle: data.title,
+        pageDescription: data.description ?? "",
+      },
+    };
+  }
+};

--- a/utils/SlugUtils.ts
+++ b/utils/SlugUtils.ts
@@ -60,6 +60,21 @@ export async function getPaths() {
   return paths;
 }
 
+export const getMajorVersionMatch = (
+  versionsList: SelectOption<string>[],
+  version: string
+) =>
+  versionsList.find((versionOption) => {
+    // Extract the major version number from the version option
+    const versionOptionNumber = REGEX_TO_EXTRACT_VERSION_NUMBER.exec(
+      versionOption.label
+    )[0];
+    // Extract the major version number from the version in the URL
+    const versionNumber = REGEX_TO_EXTRACT_VERSION_NUMBER.exec(version)[0];
+
+    return versionOptionNumber === versionNumber;
+  });
+
 export const getReturnObjectForValidVersion = ({
   context,
   paths,
@@ -106,16 +121,7 @@ export const getReturnObjectForValidVersion = ({
       // check if the major version is present.
       // Ex. If v1.4.8 is in the URL and v1.4.8 is not in versions list but v1.4.x is so match the 1.4
       // and redirect to the respective version URL in this case to v1.4.x
-      const majorVersionMatch = versionsList.find((versionOption) => {
-        // Extract the major version number from the version option
-        const versionOptionNumber = REGEX_TO_EXTRACT_VERSION_NUMBER.exec(
-          versionOption.label
-        )[0];
-        // Extract the major version number from the version in the URL
-        const versionNumber = REGEX_TO_EXTRACT_VERSION_NUMBER.exec(version)[0];
-
-        return versionOptionNumber === versionNumber;
-      });
+      const majorVersionMatch = getMajorVersionMatch(versionsList, version);
 
       return {
         redirect: {


### PR DESCRIPTION
Fix #291 
Fix partially #276 

I worked on the following functionalities:

- [x] Change the default version URL value to 'latest' and redirect the links with older or invalid versions to the latest version page
- [x] Make page title and description dynamic
- [x] If the URL version matches partially, then redirect to the respective version page.
        For example, if the URL has v1.4.5 and there is no documentation for exact v1.4.5, it is present for v1.4.x. So the user 
        will be redirected to the v1.4.x.