### PR TITLE
Don't show the collate only connector info card on the OSS docs

### DIFF
--- a/components/ConnectorInfoCard/ConnectorInfoCard.tsx
+++ b/components/ConnectorInfoCard/ConnectorInfoCard.tsx
@@ -17,6 +17,12 @@ function ConnectorInfoCard({
 }: Readonly<ConnectorInfoCardProps>) {
   const { docVersion, enableVersion } = useDocVersionContext();
 
+  // Return null if version is disabled and the connector is not collate only
+  // This is to prevent showing the collate only connectors on OSS documentation
+  if (platform == "Collate" && enableVersion) {
+    return null;
+  }
+
   return (
     <Link
       className={styles.Container}


### PR DESCRIPTION
I worked on the changes to hide the collate-only connector tiles in the content of the OSS documentation.