### PR TITLE
Youtube tag improvements to now render videos from custom URLs

### DIFF
--- a/components/common/Youtube/Youtube.interface.ts
+++ b/components/common/Youtube/Youtube.interface.ts
@@ -5,4 +5,5 @@ export interface YouTubeProps {
   end?: string;
   height?: string;
   width?: string;
+  url?: string;
 }

--- a/components/common/Youtube/Youtube.tsx
+++ b/components/common/Youtube/Youtube.tsx
@@ -17,7 +17,7 @@ const YouTube = ({
         loading="lazy"
         allowFullScreen
         src={
-          url ??
+          url ||
           `https://www.youtube-nocookie.com/embed/${videoId}?rel=0&start=${start}&end=${end}&rel=0`
         }
         className={styles.Iframe}

--- a/components/common/Youtube/Youtube.tsx
+++ b/components/common/Youtube/Youtube.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import {YouTubeProps} from "./Youtube.interface";
+import { YouTubeProps } from "./Youtube.interface";
 import styles from "./Youtube.module.css";
 
 const YouTube = ({
@@ -9,18 +9,22 @@ const YouTube = ({
   end = "",
   height,
   width,
+  url = "",
 }: YouTubeProps) => {
   return (
     <div className={classNames(styles.Container, className)}>
       <iframe
         loading="lazy"
         allowFullScreen
-        src={`https://www.youtube-nocookie.com/embed/${videoId}?rel=0&start=${start}&end=${end}&rel=0`}
+        src={
+          url ??
+          `https://www.youtube-nocookie.com/embed/${videoId}?rel=0&start=${start}&end=${end}&rel=0`
+        }
         className={styles.Iframe}
         title="YouTube video player"
         frameBorder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        style={{height, width}}
+        style={{ height, width }}
       ></iframe>
     </div>
   );

--- a/content/v1.5.x/quick-start/local-docker-deployment.md
+++ b/content/v1.5.x/quick-start/local-docker-deployment.md
@@ -10,7 +10,7 @@ This installation doc will help you start a OpenMetadata standalone instance on 
 If you'd rather see the steps in a guided tutorial, we've got you covered! Otherwise, feel free to read the
 content below 👇
 
-{%  youtube url="https://drive.google.com/file/d/16-2l9EYBE9DjlHepPKTpVFvashMy1buu/view?pli=1" start="0:00" end="6:47" width="560px" height="315px" /%}
+{%  youtube videoId="ld43_jafL9w" start="0:00" end="6:47" width="560px" height="315px" /%}
 
 # Requirements (OSX, Linux and Windows)
 

--- a/content/v1.5.x/quick-start/local-docker-deployment.md
+++ b/content/v1.5.x/quick-start/local-docker-deployment.md
@@ -10,7 +10,7 @@ This installation doc will help you start a OpenMetadata standalone instance on 
 If you'd rather see the steps in a guided tutorial, we've got you covered! Otherwise, feel free to read the
 content below 👇
 
-{%  youtube videoId="ld43_jafL9w" start="0:00" end="6:47" width="560px" height="315px" /%}
+{%  youtube url="https://drive.google.com/file/d/16-2l9EYBE9DjlHepPKTpVFvashMy1buu/view?pli=1" start="0:00" end="6:47" width="560px" height="315px" /%}
 
 # Requirements (OSX, Linux and Windows)
 

--- a/markdoc/tags/youtube.markdoc.ts
+++ b/markdoc/tags/youtube.markdoc.ts
@@ -20,5 +20,8 @@ export const youtube = {
     width: {
       type: Boolean,
     },
+    url: {
+      type: String,
+    },
   },
 };


### PR DESCRIPTION
I worked on adding a new `url` prop in the `youtube` tag to now embed videos from custom URLs.

```
{%  youtube url="https://your-video-embed-url.com" start="0:00" end="6:47" width="560px" height="315px" /%}
```