### PR TITLE
Minor: Docs improvements

### DIFF
--- a/components/PageLayouts/DocsPageLayout/DocsPageLayout.tsx
+++ b/components/PageLayouts/DocsPageLayout/DocsPageLayout.tsx
@@ -100,7 +100,9 @@ function DocsPageLayout({
         <div
           className={classNames(
             "content",
-            sideNavCollapsed ? "collapsed-content" : "non-collapsed-content",
+            sideNavCollapsed || isHowToGuidesHomePagePath
+              ? "collapsed-content"
+              : "non-collapsed-content",
             { "mx-auto": isHowToGuidesHomePagePath }
           )}
         >

--- a/components/SelectDropdown/SelectDropdown.module.css
+++ b/components/SelectDropdown/SelectDropdown.module.css
@@ -8,7 +8,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: 8px;
   margin-left: 32px;
   padding: 0px 12px;
   cursor: pointer;

--- a/constants/version.constants.ts
+++ b/constants/version.constants.ts
@@ -11,7 +11,16 @@ export const VERSION_SELECT_DEFAULT_OPTIONS: Array<SelectOption<string>> = [
   },
 ];
 
-export const REGEX_VERSION_MATCH = /(v\d+\.\d+\.\w+)|latest/;
+// The regex will match all the following:
+// v1.6.x-SNAPSHOT, v1.6.x, latest
+export const REGEX_VERSION_MATCH =
+  /(v\d+\.\d+\.\w+-SNAPSHOT)|latest|(v\d+\.\d+\.\w+)/;
+
+// The regex will match all the following:
+// /v1.6.x-SNAPSHOT, /v1.6.x, /latest
 export const REGEX_VERSION_MATCH_WITH_SLASH_AT_START =
-  /^\/((v\d+\.\d+\.\w+)|latest)/g;
+  /^\/((v\d+\.\d+\.\w+-SNAPSHOT)|latest|(v\d+\.\d+\.\w+))/g;
+
+// The regex will match all the following:
+// 1.6
 export const REGEX_TO_EXTRACT_VERSION_NUMBER = /\d+\.\d+/;

--- a/public/globals.css
+++ b/public/globals.css
@@ -8,7 +8,7 @@
   --side-nav-width: 288px;
   --side-nav-collapsed-width: 42px;
   --select-dropdown-default-height: 28px;
-  --select-dropdown-default-width: 130px;
+  --select-dropdown-default-width: 165px;
   --side-nav-width: min(20%, 300px);
   --api-side-nav-width: max(14%, 220px);
   --content-div-width: min(17%, 250px);


### PR DESCRIPTION
Fixes #342 

I worked on the following:

- [x] Fix the redirection issue from the `SNAPSHOT` version to the `latest` version.
**Before:**

https://github.com/user-attachments/assets/a03f7257-7740-4402-bb6d-5927641f1e56

**After:**

https://github.com/user-attachments/assets/5f613111-8032-4930-990c-1c71807e2b15

- [x] Fix the version selection text overflow and the sidebar for the `SNAPSHOT` version.
**Before:**

<img width="1439" alt="Screenshot 2024-12-11 at 5 42 40 PM" src="https://github.com/user-attachments/assets/802084b8-383c-48fa-8ee7-c273cbd4bfd7">

**After:**

<img width="1440" alt="Screenshot 2024-12-11 at 5 43 38 PM" src="https://github.com/user-attachments/assets/503d85c4-7fa9-45a6-995f-f2feb069af75">

- [x] Fix the issue of `how-to guides` content for the homepage not shown on mobile devices.
**Before:**

https://github.com/user-attachments/assets/fe5f56ef-e6e7-47f6-a9cd-390abf724c15

**After:**

https://github.com/user-attachments/assets/c781aab8-c814-4480-bcbd-3a7294826708
