### PR TITLE
Minor: Update connectors info and icons

### DIFF
--- a/components/ConnectorsInfo/ConnectorsInfo.constants.ts
+++ b/components/ConnectorsInfo/ConnectorsInfo.constants.ts
@@ -2,6 +2,16 @@ import { ConnectorCategory } from "./ConnectorsInfo.interface";
 
 export const CONNECTORS: Array<ConnectorCategory> = [
   {
+    connector: "API",
+    services: [
+      {
+        url: "/connectors/api/rest",
+        icon: "/images/connectors/rest.webp",
+        name: "REST",
+      },
+    ],
+  },
+  {
     connector: "Database",
     services: [
       {
@@ -272,6 +282,11 @@ export const CONNECTORS: Array<ConnectorCategory> = [
         name: "Redash",
       },
       {
+        url: "/connectors/dashboard/sigma",
+        icon: "/images/connectors/sigma.webp",
+        name: "Sigma",
+      },
+      {
         url: "/connectors/dashboard/superset",
         icon: "/images/connectors/superset.webp",
         name: "Superset",
@@ -317,6 +332,12 @@ export const CONNECTORS: Array<ConnectorCategory> = [
         name: "Dagster",
       },
       {
+        url: "/connectors/pipeline/datafactory",
+        icon: "/images/connectors/datafactory.webp",
+        name: "DataFactory",
+        collate: true,
+      },
+      {
         url: "/connectors/pipeline/dbtcloud",
         icon: "/images/connectors/dbtcloud.webp",
         name: "dbt Cloud",
@@ -330,6 +351,12 @@ export const CONNECTORS: Array<ConnectorCategory> = [
         url: "/connectors/pipeline/flink",
         icon: "/images/connectors/flink.webp",
         name: "Flink",
+      },
+      {
+        url: "/connectors/pipeline/matillion",
+        icon: "/images/connectors/matillion.webp",
+        name: "Matillion",
+        collate: true,
       },
       {
         url: "/connectors/pipeline/nifi",
@@ -346,6 +373,12 @@ export const CONNECTORS: Array<ConnectorCategory> = [
         icon: "/images/connectors/spline.webp",
         name: "Spline",
       },
+      {
+        url: "/connectors/pipeline/stitch",
+        icon: "/images/connectors/stitch.webp",
+        name: "Stitch",
+        collate: true,
+      },
     ],
   },
   {
@@ -360,6 +393,12 @@ export const CONNECTORS: Array<ConnectorCategory> = [
         url: "/connectors/ml-model/sagemaker",
         icon: "/images/connectors/sagemaker.webp",
         name: "SageMaker",
+      },
+      {
+        url: "/connectors/ml-model/vertexai",
+        icon: "/images/connectors/vertexai.webp",
+        name: "VertexAI",
+        collate: true,
       },
     ],
   },

--- a/components/ConnectorsInfo/ConnectorsInfo.interface.ts
+++ b/components/ConnectorsInfo/ConnectorsInfo.interface.ts
@@ -3,6 +3,7 @@ export interface ConnectorServiceDetails {
   icon: string;
   name: string;
   supportedVersion?: string;
+  collate?: boolean;
 }
 export interface ConnectorCategory {
   connector: string;

--- a/components/ConnectorsInfo/ConnectorsInfo.tsx
+++ b/components/ConnectorsInfo/ConnectorsInfo.tsx
@@ -1,10 +1,10 @@
 import classNames from "classnames";
-import { uniqBy } from "lodash";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useDocVersionContext } from "../../context/DocVersionContext";
 import {
+  getConnectorsList,
   getConnectorURL,
   getSortedServiceList,
 } from "../../utils/ConnectorsUtils";
@@ -18,23 +18,22 @@ const ConnectorImage = dynamic(() => import("./ConnectorImage"), {
   loading: () => <Loader size={28} />,
 });
 
-CONNECTORS.unshift({
-  connector: "All connectors",
-  services: CONNECTORS.reduce((prev, curr) => {
-    return uniqBy([...prev, ...curr.services], "name");
-  }, [] as ConnectorCategory["services"]),
-});
-
 export default function ConnectorsInfo({ tabStyle, activeTabStyle }) {
-  const { docVersion } = useDocVersionContext();
+  const { docVersion, enableVersion } = useDocVersionContext();
+
+  const connectorsList = useMemo(
+    () => getConnectorsList(CONNECTORS, enableVersion),
+    [enableVersion]
+  );
+
   const [selectedTab, setSelectedTab] = useState<ConnectorCategory>(
-    CONNECTORS[0]
+    connectorsList[0]
   );
 
   return (
     <div className={styles.Container}>
       <div className={styles.TabsContainer}>
-        {CONNECTORS.map((connectorCategory) => (
+        {connectorsList.map((connectorCategory) => (
           <button
             className={classNames(
               tabStyle,

--- a/utils/ConnectorsUtils.tsx
+++ b/utils/ConnectorsUtils.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { sortBy } from "lodash";
+import { sortBy, uniqBy } from "lodash";
 import connectorInfoStyles from "../components/ConnectorInfoCard/ConnectorInfoCard.module.css";
 import ConnectorImage from "../components/ConnectorsInfo/ConnectorImage";
 import {
@@ -72,7 +72,7 @@ export const getConnectorImage = (connector: string) => {
     Airbyte: "airbyte",
     Airflow: "airflow",
     Alation: "alation",
-    "AlationSink": "alation",
+    AlationSink: "alation",
     Amundsen: "amundsen",
     Athena: "athena",
     Atlas: "atlas",
@@ -85,6 +85,7 @@ export const getConnectorImage = (connector: string) => {
     Databricks: "databrick",
     "Databricks Pipeline": "databrick",
     "Databricks SQL": "databrick",
+    DataFactory: "datafactory",
     DB2: "ibmdb2",
     Dagster: "dagster",
     "S3 Datalake": "amazon-s3",
@@ -114,6 +115,7 @@ export const getConnectorImage = (connector: string) => {
     Lightdash: "lightdash",
     Looker: "looker",
     MariaDB: "mariadb",
+    Matillion: "matillion",
     Metabase: "metabase",
     MicroStrategy: "microstrategy",
     MLflow: "mlflow",
@@ -134,22 +136,26 @@ export const getConnectorImage = (connector: string) => {
     Redash: "redash",
     Redpanda: "redpanda",
     Redshift: "redshift",
+    REST: "rest",
     Salesforce: "salesforce",
     "SAP ERP": "sap-erp",
     "SAP Hana": "sap-hana",
     SAS: "sas",
     "S3 Storage": "amazon-s3",
     Sagemaker: "sagemaker",
+    Sigma: "sigma",
     SingleStore: "singlestore",
     Snowflake: "snowflakes",
     Spline: "spline",
     SQLite: "sqlite",
+    Stitch: "stitch",
     Superset: "superset",
     Tableau: "tableau",
     Teradata: "teradata",
     Trino: "trino",
     "Unity Catalog": "databrick",
     Vertica: "vertica",
+    VertexAI: "vertexai",
   };
 
   iconSource = connectorMappings[connector] || iconSource;
@@ -160,4 +166,31 @@ export const getConnectorImage = (connector: string) => {
       src={`/images/connectors/${iconSource}.webp`}
     />
   );
+};
+
+export const getConnectorsList = (
+  connectors: ConnectorCategory[],
+  enableVersion: boolean
+) => {
+  let connectorsList = connectors;
+
+  if (enableVersion) {
+    connectorsList = connectors.map((connectorCategory) => ({
+      ...connectorCategory,
+      services: connectorCategory.services.filter(
+        (service) => !service.collate
+      ),
+    }));
+  }
+
+  if (connectorsList[0].connector !== "All connectors") {
+    connectorsList.unshift({
+      connector: "All connectors",
+      services: connectorsList.reduce((prev, curr) => {
+        return uniqBy([...prev, ...curr.services], "name");
+      }, [] as ConnectorCategory["services"]),
+    });
+  }
+
+  return connectorsList;
 };


### PR DESCRIPTION
I worked on the following:

- [x] Update the connectors list on the homepage.

1. VertexAI (Collate)
2. Mattilion (Collate)
3. Sigma
4. DataFactory (Collate)
5. Stitch (Collate)

- [x] Add new connector icons mapping

https://github.com/user-attachments/assets/65a077e5-dd18-410c-810d-f31733a82d72

