### PR TITLE
Update breadcrumb url structure

### DIFF
--- a/components/Breadcrumb/Breadcrumb.tsx
+++ b/components/Breadcrumb/Breadcrumb.tsx
@@ -5,6 +5,7 @@ import { useDocVersionContext } from "../../context/DocVersionContext";
 import styles from "./Breadcrumb.module.css";
 import ParamLink from "../ParamLink";
 import { getUrl } from "../../utils/CommonUtils";
+import { useRouter } from "next/router";
 
 interface Crumb {
   title: string;
@@ -13,7 +14,8 @@ interface Crumb {
 }
 
 export default function Breadcrumb({ slug }: { slug: string[] }) {
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const router = useRouter();
+  const { enableVersion } = useDocVersionContext();
   const breadcrumb: Crumb[] = [
     {
       title: "Home",
@@ -34,7 +36,7 @@ export default function Breadcrumb({ slug }: { slug: string[] }) {
       {breadcrumb.map((crumb, idx) => {
         const hrefString = getUrl({
           url: crumb.path,
-          docVersion,
+          docVersion: router.query.version as string,
           enableVersion,
         });
         return (

--- a/components/Breadcrumb/Breadcrumb.tsx
+++ b/components/Breadcrumb/Breadcrumb.tsx
@@ -19,7 +19,7 @@ export default function Breadcrumb({ slug }: { slug: string[] }) {
   const breadcrumb: Crumb[] = [
     {
       title: "Home",
-      path: "",
+      path: "/",
     },
   ];
 

--- a/components/Breadcrumb/Breadcrumb.tsx
+++ b/components/Breadcrumb/Breadcrumb.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode } from "react";
 import { useDocVersionContext } from "../../context/DocVersionContext";
 import styles from "./Breadcrumb.module.css";
 import ParamLink from "../ParamLink";
+import { getUrl } from "../../utils/CommonUtils";
 
 interface Crumb {
   title: string;
@@ -24,16 +25,18 @@ export default function Breadcrumb({ slug }: { slug: string[] }) {
     slug.forEach((element, idx) => {
       breadcrumb.push({
         title: element,
-        path: slug.slice(0, idx + 1).join("/"),
+        path: `/${slug.slice(0, idx + 1).join("/")}`,
       });
     });
 
   return slug ? (
     <div className={styles.Container}>
       {breadcrumb.map((crumb, idx) => {
-        const hrefString = enableVersion
-          ? `/${docVersion}/${crumb.path}`
-          : `/${crumb.path}`;
+        const hrefString = getUrl({
+          url: crumb.path,
+          docVersion,
+          enableVersion,
+        });
         return (
           <React.Fragment key={crumb.path}>
             <ParamLink

--- a/components/CategoriesNav/CategoriesNav.tsx
+++ b/components/CategoriesNav/CategoriesNav.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export default function CategoriesNav({ menu }: Props) {
   const router = useRouter();
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const { enableVersion } = useDocVersionContext();
   const { navBarCollapsed } = useNavBarCollapsedContext();
   const category =
     getCategoryByIndex(router.asPath.split('?')[0], enableVersion ? 2 : 1) ?? "";
@@ -26,7 +26,7 @@ export default function CategoriesNav({ menu }: Props) {
     withoutVersionPath?: boolean;
   }) => {
     if (item.value.startsWith("/") && !item.withoutVersionPath) {
-      router.push(getUrlWithVersion(item.value, docVersion));
+      router.push(getUrlWithVersion(item.value, router.query.version as string));
     } else {
       window.open(item.value, "_blank").focus();
     }
@@ -45,7 +45,7 @@ export default function CategoriesNav({ menu }: Props) {
 
           return (
             <ParamLink
-              href={getUrl({ url: item.url, docVersion, enableVersion })}
+              href={getUrl({ url: item.url, docVersion: router.query.version as string, enableVersion })}
               key={item.url}
               className={classNames(
                 styles.NavItem,

--- a/components/ConnectorInfoCard/ConnectorInfoCard.tsx
+++ b/components/ConnectorInfoCard/ConnectorInfoCard.tsx
@@ -8,6 +8,7 @@ import {
 import { ConnectorInfoCardProps } from "./ConnectorInfoCard.interface";
 import styles from "./ConnectorInfoCard.module.css";
 import ParamLink from "../ParamLink";
+import { useRouter } from "next/router";
 
 function ConnectorInfoCard({
   name,
@@ -15,7 +16,8 @@ function ConnectorInfoCard({
   platform,
   href,
 }: Readonly<ConnectorInfoCardProps>) {
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const router = useRouter();
+  const { enableVersion } = useDocVersionContext();
 
   // Return null if version is disabled and the connector is not collate only
   // This is to prevent showing the collate only connectors on OSS documentation
@@ -26,7 +28,7 @@ function ConnectorInfoCard({
   return (
     <ParamLink
       className={styles.Container}
-      href={getUrl({ url: href, docVersion, enableVersion })}
+      href={getUrl({ url: href, docVersion: router.query.version as string, enableVersion })}
     >
       <div className="flex items-center gap-2">
         <div className={styles.ImageContainer}>{getConnectorImage(name)}</div>

--- a/components/ConnectorsInfo/ConnectorsInfo.constants.ts
+++ b/components/ConnectorsInfo/ConnectorsInfo.constants.ts
@@ -485,11 +485,6 @@ export const CONNECTORS: Array<ConnectorCategory> = [
     connector: "Metadata",
     services: [
       {
-        url: "/connectors/metadata/alation",
-        icon: "/images/connectors/alation.webp",
-        name: "Alation",
-      },
-      {
         url: "/connectors/metadata/alationsink",
         icon: "/images/connectors/alation.webp",
         name: "AlationSink",

--- a/components/ConnectorsInfo/ConnectorsInfo.constants.ts
+++ b/components/ConnectorsInfo/ConnectorsInfo.constants.ts
@@ -485,6 +485,12 @@ export const CONNECTORS: Array<ConnectorCategory> = [
     connector: "Metadata",
     services: [
       {
+        url: "/connectors/metadata/alation",
+        icon: "/images/connectors/alation.webp",
+        name: "Alation",
+        collate: true,
+      },
+      {
         url: "/connectors/metadata/alationsink",
         icon: "/images/connectors/alation.webp",
         name: "AlationSink",

--- a/components/ConnectorsInfo/ConnectorsInfo.tsx
+++ b/components/ConnectorsInfo/ConnectorsInfo.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from "react";
 import { useDocVersionContext } from "../../context/DocVersionContext";
 import {
   getConnectorsList,
-  getConnectorURL,
   getSortedServiceList,
 } from "../../utils/ConnectorsUtils";
 import Loader from "../common/Loader/Loader";
@@ -12,6 +11,8 @@ import { CONNECTORS } from "./ConnectorsInfo.constants";
 import { ConnectorCategory } from "./ConnectorsInfo.interface";
 import styles from "./ConnectorsInfo.module.css";
 import ParamLink from "../ParamLink";
+import { getUrl } from "../../utils/CommonUtils";
+import { useRouter } from "next/router";
 
 const ConnectorImage = dynamic(() => import("./ConnectorImage"), {
   ssr: false,
@@ -19,7 +20,8 @@ const ConnectorImage = dynamic(() => import("./ConnectorImage"), {
 });
 
 export default function ConnectorsInfo({ tabStyle, activeTabStyle }) {
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const { enableVersion } = useDocVersionContext();
+  const router = useRouter();
 
   const connectorsList = useMemo(
     () => getConnectorsList(CONNECTORS, enableVersion),
@@ -53,7 +55,7 @@ export default function ConnectorsInfo({ tabStyle, activeTabStyle }) {
           {getSortedServiceList(selectedTab.services).map((connector) => (
             <ParamLink
               className={styles.ConnectorItem}
-              href={getConnectorURL(docVersion, connector)}
+              href={getUrl({ url: connector.url, docVersion: router.query.version as string, enableVersion })}
               key={connector.name}
             >
               <ConnectorImage

--- a/components/PageLayouts/APIPageLayout/APIPageContent/APIPageContent.tsx
+++ b/components/PageLayouts/APIPageLayout/APIPageContent/APIPageContent.tsx
@@ -23,10 +23,10 @@ function APIsPageContent({
   pageInfoObject,
 }: APIsPageContentProps) {
   const router = useRouter();
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const { enableVersion } = useDocVersionContext();
   const handleMenuItemClick = (item: DropdownMenuItem) => {
     if (item.value.startsWith("/")) {
-      router.push(getUrl({ url: item.value, docVersion, enableVersion }));
+      router.push(getUrl({ url: item.value, docVersion: router.query.version as string, enableVersion }));
     } else {
       window.open(item.value, "_blank").focus();
     }

--- a/components/PageLayouts/APIPageLayout/APIPageSideNav/APIPageSideNav.tsx
+++ b/components/PageLayouts/APIPageLayout/APIPageSideNav/APIPageSideNav.tsx
@@ -11,6 +11,7 @@ import APILeftPanelItem from "../../../APILeftPanelItem/APILeftPanelItem";
 import APISearchModal from "../../../modals/APISearchModal/APISearchModal";
 import styles from "./APIPageSideNav.module.css";
 import ParamLink from "../../../ParamLink";
+import { useRouter } from "next/router";
 
 export interface HeadingObject {
   label: string;
@@ -31,7 +32,8 @@ function APIPageSideNav({ pageInfoObject }: APIPageSideNavProps) {
   const [nestedHeadings, setNestedHeadings] = useState<Array<HeadingObject>>(
     []
   );
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const router = useRouter();
+  const { enableVersion } = useDocVersionContext();
   const [searchModalVisibility, setSearchModalVisibility] =
     useState<boolean>(false);
 
@@ -101,7 +103,7 @@ function APIPageSideNav({ pageInfoObject }: APIPageSideNavProps) {
     <div className={styles.APIPageSideNavContainer}>
       <ParamLink
         className={styles.Heading}
-        href={getUrl({ url: pageInfoObject.value, docVersion, enableVersion })}
+        href={getUrl({ url: pageInfoObject.value, docVersion: router.query.version as string, enableVersion })}
       >
         <OmLogo className={styles.OpenMetadataLogo} />
         <span className={styles.Api}>{pageInfoObject.label}</span>

--- a/components/Roadmap/Roadmap.tsx
+++ b/components/Roadmap/Roadmap.tsx
@@ -12,9 +12,11 @@ import { Heading } from "../Heading/Heading";
 import styles from "./Roadmap.module.css";
 import RoadmapFeatureItem from "./RoadmapFeatureItem/RoadmapFeatureItem";
 import ParamLink from "../ParamLink";
+import { useRouter } from "next/router";
 
 function Roadmap() {
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const router = useRouter();
+  const { enableVersion } = useDocVersionContext();
   const [showLeftShadow, setShowLeftShadow] = useState(false);
   const [showRightShadow, setShowRightShadow] = useState(true);
   const tableRef = useRef(null);
@@ -72,7 +74,7 @@ function Roadmap() {
       <p>
         You can check the latest release{" "}
         <ParamLink
-          href={getUrl({ url: ALL_RELEASES_URL, docVersion, enableVersion })}
+          href={getUrl({ url: ALL_RELEASES_URL, docVersion: router.query.version as string, enableVersion })}
           name="here"
         />
         .

--- a/components/Search/HitComponent/HitComponent.tsx
+++ b/components/Search/HitComponent/HitComponent.tsx
@@ -6,10 +6,12 @@ import { useSearchContext } from "../../../context/SearchContext";
 import { getUrl } from "../../../utils/CommonUtils";
 import styles from "../Search.module.css";
 import ParamLink from "../../ParamLink";
+import { useRouter } from "next/router";
 
 function HitComponent(props) {
   const { focusedSearchItem, onChangeFocusedSearchItem } = useSearchContext();
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const { enableVersion } = useDocVersionContext();
+  const router = useRouter();
   const articleItemRef = useRef<HTMLElement>();
 
   const category = props.hit.categories
@@ -38,7 +40,7 @@ function HitComponent(props) {
   return (
     <ParamLink
       className={classNames(styles.HitLink)}
-      href={getUrl({ url: props.hit.objectID, docVersion, enableVersion })}
+      href={getUrl({ url: props.hit.objectID, docVersion: router.query.version as string, enableVersion })}
     >
       <article
         className={classNames(

--- a/components/SideNav/ListItem.tsx
+++ b/components/SideNav/ListItem.tsx
@@ -15,7 +15,7 @@ export default function ListItem({
   fontWeight,
 }: Readonly<ListItemProps>) {
   const router = useRouter();
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const { enableVersion } = useDocVersionContext();
   const linkRef = useRef<HTMLAnchorElement>();
 
   const isDropdown = item.children && item.children.length > 0;
@@ -36,7 +36,7 @@ export default function ListItem({
     setIsOpen((open) => !open);
   };
 
-  const urlWithVersion = getUrl({ url: item.url, docVersion, enableVersion });
+  const urlWithVersion = getUrl({ url: item.url, docVersion: router.query.version as string, enableVersion });
 
   const linkItem = useMemo(() => {
     return (

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -6,6 +6,7 @@ import { ReactNode, useCallback, useEffect, useState } from "react";
 import { MdMenu, MdMenuOpen } from "react-icons/md";
 import { InstantSearch } from "react-instantsearch";
 import {
+  DEFAULT_VERSION,
   REGEX_VERSION_MATCH,
   REGEX_VERSION_MATCH_WITH_SLASH_AT_START,
 } from "../../constants/version.constants";
@@ -42,10 +43,11 @@ export default function TopNav({ versionsList, logo }: Readonly<TopNavProps>) {
     useNavBarCollapsedContext();
 
   const handleVersionChange = (value: string) => {
+    const updatedValue = value === DEFAULT_VERSION ? "latest" : value;
     const path =
       router.asPath === "/"
-        ? `/${value}`
-        : router.asPath.replace(REGEX_VERSION_MATCH, value);
+        ? `/${updatedValue}`
+        : router.asPath.replace(REGEX_VERSION_MATCH, updatedValue);
 
     router.push(path);
   };

--- a/components/TopNav/TopNav.tsx
+++ b/components/TopNav/TopNav.tsx
@@ -88,7 +88,7 @@ export default function TopNav({ versionsList, logo }: Readonly<TopNavProps>) {
       <div className={styles.CollapsedDivContainer}>
         <div className={styles.LogoContainer}>
           <ParamLink
-            href={getUrl({ url: "/", docVersion, enableVersion })}
+            href={getUrl({ url: "/", docVersion: router.query.version as string, enableVersion })}
             aria-label="omd-icon"
           >
             {isUndefined(logo) ? <OMDIcon /> : logo}

--- a/components/common/Button/Button.tsx
+++ b/components/common/Button/Button.tsx
@@ -4,6 +4,7 @@ import { useDocVersionContext } from "../../../context/DocVersionContext";
 import { getUrl } from "../../../utils/CommonUtils";
 import styles from "./Button.module.css";
 import ParamLink from "../../ParamLink";
+import { useRouter } from "next/router";
 
 interface Props extends HTMLAttributes<HTMLButtonElement> {
   href?: string;
@@ -21,12 +22,12 @@ export default function Button({
   style,
   isExternalLink = false,
 }: Props) {
-  const { docVersion, enableVersion } = useDocVersionContext();
-
+  const { enableVersion } = useDocVersionContext();
+  const router = useRouter();
   return type === "link" ? (
     <ParamLink
       className={classNames(styles.Container, className)}
-      href={getUrl({ url: href, docVersion, enableVersion, isExternalLink })}
+      href={getUrl({ url: href, docVersion: router.query.version as string, enableVersion, isExternalLink })}
       id={id}
       style={style}
     >

--- a/components/common/Card/Card.tsx
+++ b/components/common/Card/Card.tsx
@@ -5,6 +5,7 @@ import styles from "./Card.module.css";
 import { getUrl } from "../../../utils/CommonUtils";
 import { useDocVersionContext } from "../../../context/DocVersionContext";
 import ParamLink from "../../ParamLink";
+import { useRouter } from "next/router";
 
 interface Props {
   heading: string;
@@ -21,12 +22,12 @@ export default function Card({
   isExternalLink = false,
   icon,
 }: Props) {
-  const { docVersion, enableVersion } = useDocVersionContext();
-
+  const { enableVersion } = useDocVersionContext();
+  const router = useRouter();
   return (
     <ParamLink
       className={styles.Container}
-      href={getUrl({ url, docVersion, enableVersion, isExternalLink })}
+      href={getUrl({ url, docVersion: router.query.version as string, enableVersion, isExternalLink })}
     >
       {icon ? icon : <Puzzle />}
       <div className={styles.Heading}>{heading}</div>

--- a/components/common/CustomAnchorNode/CustomAnchorNode.tsx
+++ b/components/common/CustomAnchorNode/CustomAnchorNode.tsx
@@ -3,6 +3,7 @@ import { getUrl } from "../../../utils/CommonUtils";
 import { PAGES_WITHOUT_VERSION } from "../../../constants/pagesWithoutVersion.constants";
 import { useDocVersionContext } from "../../../context/DocVersionContext";
 import ParamLink from "../../ParamLink";
+import { useRouter } from "next/router";
 
 interface Props {
   href: string;
@@ -10,7 +11,8 @@ interface Props {
 }
 
 function CustomAnchorNode({ href, children }: Props) {
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const { enableVersion } = useDocVersionContext();
+  const router = useRouter();
   const regexToIdentifyLink = /^(http|https|ftp|www)/g;
 
   const isExternalLink = href.search(regexToIdentifyLink) !== -1;
@@ -23,7 +25,7 @@ function CustomAnchorNode({ href, children }: Props) {
     <ParamLink
       href={getUrl({
         url: href,
-        docVersion,
+        docVersion: router.query.version as string,
         enableVersion,
         isExternalLink: disableVersion,
       })}

--- a/components/common/HomePageBanner/HomePageBanner.tsx
+++ b/components/common/HomePageBanner/HomePageBanner.tsx
@@ -9,12 +9,14 @@ import YouTube from "../Youtube/Youtube";
 import { HomePageBannerProps } from "./HomePageBanner.interface";
 import styles from "./HomePageBanner.module.css";
 import ParamLink from "../../ParamLink";
+import { useRouter } from "next/router";
 
 export default function HomePageBanner({
   quickLinks,
   bannerInfo,
 }: Readonly<HomePageBannerProps>) {
-  const { docVersion, enableVersion } = useDocVersionContext();
+  const { enableVersion } = useDocVersionContext();
+  const router = useRouter();
 
   const getLinkButtonStyleFromTheme = useCallback(
     (theme: string) => {
@@ -59,7 +61,7 @@ export default function HomePageBanner({
                 <ParamLink
                   href={getUrl({
                     url: href,
-                    docVersion,
+                    docVersion: router.query.version as string,
                     enableVersion,
                     isExternalLink: externalURL,
                   })}

--- a/components/common/InlineCallout/InlineCallout.tsx
+++ b/components/common/InlineCallout/InlineCallout.tsx
@@ -7,6 +7,7 @@ import { ReactNode, useMemo } from "react";
 import { useDocVersionContext } from "../../../context/DocVersionContext";
 import styles from "./InlineCallout.module.css";
 import ParamLink from "../../ParamLink";
+import { useRouter } from "next/router";
 
 interface InlineCalloutProps {
   icon: string;
@@ -23,8 +24,8 @@ const InlineCallout = ({
   href,
   isExternalLink = false,
 }: InlineCalloutProps) => {
-  const { docVersion, enableVersion } = useDocVersionContext();
-
+  const { enableVersion } = useDocVersionContext();
+  const router = useRouter();
   const iconComponent = useMemo(() => {
     switch (icon) {
       case "celebration":
@@ -41,7 +42,7 @@ const InlineCallout = ({
   return (
     <ParamLink
       className={classNames(styles.Container)}
-      href={getUrl({ url: href, docVersion, enableVersion, isExternalLink })}
+      href={getUrl({ url: href, docVersion: router.query.version as string, enableVersion, isExternalLink })}
       target={isExternalLink ? "_blank" : "_self"}
     >
       <span className={classNames(styles.IconContainer)}>{iconComponent}</span>

--- a/components/common/Tiles/Tile/Tile.tsx
+++ b/components/common/Tiles/Tile/Tile.tsx
@@ -7,6 +7,7 @@ import { getTileIcons } from "../../../../utils/TileUtils";
 import { TileProps } from "./Tile.interface";
 import styles from "./Tile.module.css";
 import ParamLink from "../../../ParamLink";
+import { useRouter } from "next/router";
 
 function Tile({
   description,
@@ -16,14 +17,14 @@ function Tile({
   icon,
   children,
 }: TileProps) {
-  const { docVersion, enableVersion } = useDocVersionContext();
-
+  const { enableVersion } = useDocVersionContext();
+  const router = useRouter();
   const getWrappedTile = useCallback(
     (tileContainer: JSX.Element): JSX.Element =>
       link ? (
         <ParamLink
           target={isExternalLink ? "_blank" : "_self"}
-          href={getUrl({ url: link, docVersion, enableVersion, isExternalLink })}
+          href={getUrl({ url: link, docVersion: router.query.version as string, enableVersion, isExternalLink })}
         >
           {tileContainer}
         </ParamLink>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -45,7 +45,7 @@ export const getVersionsList = () => {
       .filter((version) => REGEX_VERSION_MATCH.test(version))
       .map((version) => ({
         label: version,
-        value: version === DEFAULT_VERSION ? "latest" : version,
+        value: version,
       }));
 
     const sortedVersion = sortBy(versionsList, "label").reverse();

--- a/pages/[version]/[...slug].tsx
+++ b/pages/[version]/[...slug].tsx
@@ -9,7 +9,6 @@ import { SelectOption } from "../../components/SelectDropdown/SelectDropdown";
 import TopNav from "../../components/TopNav/TopNav";
 import { API_AND_SDK_MENU_ITEMS } from "../../constants/categoriesNav.constants";
 import {
-  DEFAULT_VERSION,
   REGEX_VERSION_MATCH,
 } from "../../constants/version.constants";
 import { getVersionsList } from "../../lib/api";
@@ -85,18 +84,6 @@ export async function getServerSideProps(
 ): Promise<GetServerSidePropsResult<SlugProps>> {
   try {
     const version = context.params.version as string;
-    const slug = context.params.slug as string[];
-    const pathWithoutVersion = slug.join("/");
-
-    // If the version in the URL is the default version, change the path to /latest
-    if (version === DEFAULT_VERSION) {
-      return {
-        redirect: {
-          permanent: false,
-          destination: `/latest/${pathWithoutVersion}`,
-        },
-      };
-    }
 
     // Get all paths for the docs
     const paths = await getPaths();

--- a/pages/[version]/[...slug].tsx
+++ b/pages/[version]/[...slug].tsx
@@ -101,16 +101,6 @@ export async function getServerSideProps(
     // Get all paths for the docs
     const paths = await getPaths();
 
-    // Default props
-    const props: SlugProps = {
-      content: "",
-      slug: [],
-      versionsList: [],
-      partials: {},
-      pageTitle: "",
-      pageDescription: "",
-    };
-
     // Check if the version field passed in context params is proper version format
     const isVersionValid = REGEX_VERSION_MATCH.test(version);
 
@@ -131,9 +121,11 @@ export async function getServerSideProps(
           notFound: true,
         };
       }
+    } else {
+      return {
+        notFound: true,
+      };
     }
-
-    return { props };
   } catch {
     return {
       notFound: true,

--- a/pages/[version]/index.tsx
+++ b/pages/[version]/index.tsx
@@ -125,19 +125,9 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     const versionsList: Array<SelectOption<string>> = getVersionsList();
 
     if (isVersionValid) {
-      // If the version in the URL is the default version number, change the path to /latest
-      if (version === DEFAULT_VERSION) {
-        return {
-          redirect: {
-            permanent: false,
-            destination: `/latest`,
-          },
-        };
-      }
-
       // Check if the version is present in the existing versions list
       const isVersionPresent = versionsList.some(
-        (versionOption) => versionOption.value === version
+        (versionOption) => versionOption.value === version || version === 'latest'
       );
 
       if (!isVersionPresent) {
@@ -147,20 +137,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         // and redirect to the respective version URL in this case to v1.4.x
         const majorVersionMatch = getMajorVersionMatch(versionsList, version);
 
-        if (majorVersionMatch) {
-          return {
-            redirect: {
-              permanent: false,
-              destination: `/${
-                majorVersionMatch?.value ?? "latest" // If major version match is not present, redirect to latest
-              }`,
-            },
-          };
-        } else {
-          return {
-            notFound: true,
-          };
-        }
+        return {
+          redirect: {
+            permanent: false,
+            destination: `/${
+              majorVersionMatch?.value ?? "latest" // If major version match is not present, redirect to latest
+            }`,
+          },
+        };
       }
     } else {
       // If the version value is not of accepted version format, redirect to the latest version page

--- a/utils/CommonUtils.ts
+++ b/utils/CommonUtils.ts
@@ -14,7 +14,7 @@ export const generateIdFromHeading = (heading: string) => {
 };
 
 export const getUrlWithVersion = (url: string, docVersion: string) => {
-  return `/${docVersion === DEFAULT_VERSION ? "latest" : docVersion}${url}`;
+  return `/${docVersion}${url}`;
 };
 
 export const getUrl = ({


### PR DESCRIPTION
1. **Breadcrumb Issue**

- Updated the breadcrumb url to get the `/latest` in the slug instead of showing the latest version name. This is important for SEO because the link is pointing to other URL and navigating to other. This adds extra HTTP requests, slows page loads, and dilutes link equity.
- For other versions, it will show the version name as expected.

**Before:** 

<img width="1480" alt="image" src="https://github.com/user-attachments/assets/1cc4bc7e-7523-4025-a874-8f6746a8beba" />


**After:** 

![image](https://github.com/user-attachments/assets/d7c8844e-58de-47e0-931c-bd34ad0bc949)


2. **Page 200 -> 404 issue**

**Before:** 

<img width="692" alt="image" src="https://github.com/user-attachments/assets/5f6bec05-c8ad-432f-b168-359dec133bde" />


**After:** 

<img width="680" alt="image" src="https://github.com/user-attachments/assets/9e1c6ff9-96d6-4f1c-97cf-735df2759e79" />


3. **Support /v1.7.x for all pages**


https://github.com/user-attachments/assets/edc4b0ab-bf80-4d79-888a-e93a29ee86b8

