### PR TITLE
Add GitHub Actions workflow for syncing documentation with Collate

### DIFF
--- a/.github/workflows/sync-docs-with-collate
+++ b/.github/workflows/sync-docs-with-collate
@@ -59,7 +59,7 @@ jobs:
         target-branch: main
 
     - name: Slack on Failure
-      if: ${{ steps.push_content_collate.outcome != 'success' || steps.prepare_collate.outcome != 'success' }}
+      if: ${{ steps.push_content_collate.outcome != 'success' || steps.prepare_collate.outcome != 'success' || steps.push_images_collate.outcome != 'success' }}
       uses: slackapi/slack-github-action@v1.23.0
       with:
         payload: |

--- a/.github/workflows/sync-docs-with-collate
+++ b/.github/workflows/sync-docs-with-collate
@@ -1,0 +1,77 @@
+
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Sync publish docs
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Prepare Collate content and partials
+      id: prepare_collate
+      continue-on-error: true
+      run: cp -R content/partials/ content/v1.9.x/partials
+
+    - name: Push content Collate
+      id: push_content_collate
+      continue-on-error: true
+      uses: cpina/github-action-push-to-another-repository@main
+      env:
+        SSH_DEPLOY_KEY: ${{ secrets.DOCS_COLLATE_SSH_DEPLOY_KEY }}
+      with:
+        source-directory: content/v1.9.x
+        target-directory: content/
+        destination-github-username: 'open-metadata'
+        destination-repository-name: 'docs-collate'
+        user-email: collate@getcollate.io
+        commit-message: See ORIGIN_COMMIT from $GITHUB_REF
+        target-branch: main
+
+    - name: Push images Collate
+      id: push_images_collate
+      continue-on-error: true
+      uses: cpina/github-action-push-to-another-repository@main
+      env:
+        SSH_DEPLOY_KEY: ${{ secrets.DOCS_COLLATE_SSH_DEPLOY_KEY }}
+      with:
+        source-directory: public/images/
+        target-directory: public/images/
+        destination-github-username: 'open-metadata'
+        destination-repository-name: 'docs-collate'
+        user-email: collate@getcollate.io
+        commit-message: See ORIGIN_COMMIT from $GITHUB_REF
+        target-branch: main
+
+    - name: Slack on Failure
+      if: ${{ steps.push_content.outcome != 'success' || steps.push_content_collate.outcome != 'success' || steps.prepare_collate.outcome != 'success' }}
+      uses: slackapi/slack-github-action@v1.23.0
+      with:
+        payload: |
+          {
+            "text": "🔥 Docs sync failed! 🔥"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MONITOR_SLACK_WEBHOOK }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+    - name: Force failure
+      if: steps.push_content.outcome != 'success'
+      run: |
+        exit 1

--- a/.github/workflows/sync-docs-with-collate
+++ b/.github/workflows/sync-docs-with-collate
@@ -71,6 +71,6 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Force failure
-      if: steps.push_content.outcome != 'success'
+      if: steps.push_content_collate.outcome != 'success'
       run: |
         exit 1

--- a/.github/workflows/sync-docs-with-collate
+++ b/.github/workflows/sync-docs-with-collate
@@ -71,6 +71,6 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Force failure
-      if: steps.push_content_collate.outcome != 'success'
+      if: steps.push_content_collate.outcome != 'success' || steps.prepare_collate.outcome != 'success' || steps.push_images_collate.outcome != 'success'
       run: |
         exit 1

--- a/.github/workflows/sync-docs-with-collate
+++ b/.github/workflows/sync-docs-with-collate
@@ -1,4 +1,3 @@
-
 #  Copyright 2021 Collate
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -60,7 +59,7 @@ jobs:
         target-branch: main
 
     - name: Slack on Failure
-      if: ${{ steps.push_content.outcome != 'success' || steps.push_content_collate.outcome != 'success' || steps.prepare_collate.outcome != 'success' }}
+      if: ${{ steps.push_content_collate.outcome != 'success' || steps.prepare_collate.outcome != 'success' }}
       uses: slackapi/slack-github-action@v1.23.0
       with:
         payload: |


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the synchronization of documentation and images with the Collate documentation repository. This workflow is triggered on pushes to the `main` branch and can also be triggered manually. It includes steps to prepare content, push documentation and images, and notify via Slack if any steps fail.

**New documentation sync workflow:**

* Added `.github/workflows/sync-docs-with-collate` to automate syncing of documentation and images from the current repository to the `open-metadata/docs-collate` repository using GitHub Actions. The workflow handles copying partials, pushing content and images, and sending a Slack notification on failure.