### PR TITLE
Fix the styling for brand name docs tag

### DIFF
--- a/components/PageLayouts/DocsPageLayout/DocsPageLayout.tsx
+++ b/components/PageLayouts/DocsPageLayout/DocsPageLayout.tsx
@@ -130,7 +130,13 @@ function DocsPageLayout({
             ) : (
               <>
                 <Breadcrumb slug={slug} />
-                <div className={`mt-4 -mb-6 font-medium px-2 w-fit rounded-xl ${isCollate ? "bg-[#cbeef6] text-[#007e99]" : "bg-[#e5e8fb] text-[#5469d4]"}`}>
+                <div
+                  className={`brand-docs-banner ${
+                    isCollate
+                      ? "bg-[#cbeef6] text-[#007e99]"
+                      : "bg-[#e5e8fb] text-[#5469d4]"
+                  }`}
+                >
                   {isCollate ? "Collate" : "OpenMetadata"} Documentation
                 </div>
                 {Markdoc.renderers.react(parsedContent, React, {

--- a/public/globals.css
+++ b/public/globals.css
@@ -462,3 +462,15 @@ code::-webkit-scrollbar {
   transform: translateY(0); 
   visibility: visible;
 }
+
+.brand-docs-banner{
+  font-weight: 500;
+  padding: 0px 8px;
+  border-radius: 12px;
+  margin-top: 16px;
+  width: fit-content;
+}
+
+.brand-docs-banner+article> h1:first-child{
+  margin-top: 8px;
+}


### PR DESCRIPTION
**Before:**

<img width="1440" height="502" alt="Screenshot 2025-08-26 at 7 35 08 PM" src="https://github.com/user-attachments/assets/b666b57f-b42c-4596-b064-838482bec9cc" />

**After:**

<img width="1440" height="648" alt="Screenshot 2025-08-26 at 7 35 35 PM" src="https://github.com/user-attachments/assets/49659cf1-3f14-4089-9440-a52b02a4e2de" />
