### PR TITLE
1.9.4 updates

### DIFF
--- a/content/v1.9.x/how-to-guides/mcp/claude.md
+++ b/content/v1.9.x/how-to-guides/mcp/claude.md
@@ -80,7 +80,7 @@ caption="Personal Access Token expires in 60 days"
 - Paste your PAT in mcp-remote's MCP Inspector. 
   - MCP Inspector URL is [http://127.0.0.1:6274/](http://127.0.0.1:6274/)
   - *Transport Type* is SSE
-  - *URL* is <YOUR-OpenMetadata-SERVER>/mcp/sse
+  - *URL* is <YOUR-OpenMetadata-SERVER>/mcp
   - *Bearer Token* is your PAT
   - Select *Connect*
 
@@ -96,7 +96,7 @@ This how-to guide uses the free version of Claude Desktop for macOS with Sonnet 
       "args": [
         "-y",
         "mcp-remote",
-        "<YOUR-OpenMetadata-SERVER>/mcp/sse",
+        "<YOUR-OpenMetadata-SERVER>/mcp",
         "--auth-server-url=<YOUR-OpenMetadata-SERVER>/mcp",
         "--client-id=openmetadata",
         "--verbose",

--- a/content/v1.9.x/how-to-guides/mcp/goose.md
+++ b/content/v1.9.x/how-to-guides/mcp/goose.md
@@ -82,11 +82,11 @@ caption="Settings are where you add custom extensions like Collate MCP Server"
   - *Extension Name* {% collateContent %}`Collate`{% /collateContent %}{% ossContent %}`OpenMetadata`{% /ossContent %}
   - *Command* paste the following command:
     ```
-    npx -y mcp-remote <YOUR_OpenMetadata_SERVER>/mcp/sse --auth-server-url=<YOUR_OpenMetadata_SERVER>/mcp --client-id=openmetadata --verbose --clean --header Authorization:${AUTH_HEADER}
+    npx -y mcp-remote <YOUR_OpenMetadata_SERVER>/mcp --auth-server-url=<YOUR_OpenMetadata_SERVER>/mcp --client-id=openmetadata --verbose --clean --header Authorization:${AUTH_HEADER}
     ```
     - If you are running [it locally](https://docs.open-metadata.org/latest/quick-start/local-docker-deployment), your command will look like this:
       ```
-      npx -y mcp-remote http://localhost:8585/mcp/sse --auth-server-url=http://localhost:8585/mcp --client-id=openmetadata --verbose --clean --header Authorization:${AUTH_HEADER}
+      npx -y mcp-remote http://localhost:8585/mcp --auth-server-url=http://localhost:8585/mcp --client-id=openmetadata --verbose --clean --header Authorization:${AUTH_HEADER}
       ```
   - Add 1 *Environment Variable*
     - *Variable name* is `AUTH_HEADER`

--- a/content/v1.9.x/quick-start/local-docker-deployment.md
+++ b/content/v1.9.x/quick-start/local-docker-deployment.md
@@ -120,15 +120,15 @@ The latest version is at the top of the page
 You can use the curl or wget command as well to fetch the docker compose files from your terminal -
 
 ```commandline
-curl -sL -o docker-compose.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.9.1-release/docker-compose.yml
+curl -sL -o docker-compose.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.9.4-release/docker-compose.yml
 
-curl -sL -o docker-compose-postgres.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.9.1-release/docker-compose-postgres.yml
+curl -sL -o docker-compose-postgres.yml https://github.com/open-metadata/OpenMetadata/releases/download/1.9.4-release/docker-compose-postgres.yml
 ```
 
 ```commandline
-wget https://github.com/open-metadata/OpenMetadata/releases/download/1.9.1-release/docker-compose.yml
+wget https://github.com/open-metadata/OpenMetadata/releases/download/1.9.4-release/docker-compose.yml
 
-wget https://github.com/open-metadata/OpenMetadata/releases/download/1.9.1-release/docker-compose-postgres.yml
+wget https://github.com/open-metadata/OpenMetadata/releases/download/1.9.4-release/docker-compose-postgres.yml
 ```
 
 ### 3. Start the Docker Compose Services
@@ -167,10 +167,10 @@ You can validate that all containers are up by running with command `docker ps`.
 ```commandline
 ❯ docker ps
 CONTAINER ID   IMAGE                                                  COMMAND                  CREATED          STATUS                    PORTS                                                            NAMES
-470cc8149826   openmetadata/server:1.9.1                             "./openmetadata-star…"   45 seconds ago   Up 43 seconds             3306/tcp, 9200/tcp, 9300/tcp, 0.0.0.0:8585-8586->8585-8586/tcp   openmetadata_server
-63578aacbff5   openmetadata/ingestion:1.9.1                           "./ingestion_depende…"   45 seconds ago   Up 43 seconds             0.0.0.0:8080->8080/tcp                                           openmetadata_ingestion
+470cc8149826   openmetadata/server:1.9.4                             "./openmetadata-star…"   45 seconds ago   Up 43 seconds             3306/tcp, 9200/tcp, 9300/tcp, 0.0.0.0:8585-8586->8585-8586/tcp   openmetadata_server
+63578aacbff5   openmetadata/ingestion:1.9.4                           "./ingestion_depende…"   45 seconds ago   Up 43 seconds             0.0.0.0:8080->8080/tcp                                           openmetadata_ingestion
 9f5ee8334f4b   docker.elastic.co/elasticsearch/elasticsearch:7.16.3   "/tini -- /usr/local…"   45 seconds ago   Up 44 seconds             0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp                   openmetadata_elasticsearch
-08947ab3424b   openmetadata/db:1.9.1                                  "/entrypoint.sh mysq…"   45 seconds ago   Up 44 seconds (healthy)   3306/tcp, 33060-33061/tcp                                        openmetadata_mysql
+08947ab3424b   openmetadata/db:1.9.4                                  "/entrypoint.sh mysq…"   45 seconds ago   Up 44 seconds (healthy)   3306/tcp, 33060-33061/tcp                                        openmetadata_mysql
 ```
 
 In a few seconds, you should be able to access the OpenMetadata UI at [http://localhost:8585](http://localhost:8585)


### PR DESCRIPTION
Updated command examples in goose.md to remove '/sse' from the mcp path.