### PR TITLE
Render Params Properly

### DIFF
--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/ometa_api.md
@@ -255,7 +255,21 @@ list_all_entities(
 ) → Iterable[~T]
 ```
 
-Utility method that paginates over all EntityLists to return a generator to fetch entities :param entity: Entity Type, such as Table :param fields: Extra fields to return :param limit: Number of entities in each pagination :param params: Extra parameters, e.g., {"service": "serviceName"} to filter :return: Generator that will be yielding all Entities 
+Utility method that paginates over all EntityLists to return a generator to fetch entities 
+
+**Parameters**:
+
+- `entity`: Entity Type, such as Table
+
+- `fields`: Extra fields to return
+
+- `limit`: Number of entities in each pagination
+
+- `params`: Extra parameters, e.g., {"service": "serviceName"} to filter
+
+**Returns**:
+
+Generator that will be yielding all Entities 
 
 ---
 

--- a/content/v1.8.x/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.8.x/sdk/python/api-reference/ometa_api.md
@@ -255,7 +255,21 @@ list_all_entities(
 ) → Iterable[~T]
 ```
 
-Utility method that paginates over all EntityLists to return a generator to fetch entities :param entity: Entity Type, such as Table :param fields: Extra fields to return :param limit: Number of entities in each pagination :param params: Extra parameters, e.g., {"service": "serviceName"} to filter :return: Generator that will be yielding all Entities 
+Utility method that paginates over all EntityLists to return a generator to fetch entities 
+
+**Parameters**:
+
+- `entity`: Entity Type, such as Table
+
+- `fields`: Extra fields to return
+
+- `limit`: Number of entities in each pagination
+
+- `params`: Extra parameters, e.g., {"service": "serviceName"} to filter
+
+**Returns**:
+
+Generator that will be yielding all Entities 
 
 ---
 

--- a/content/v1.9.x/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.9.x/sdk/python/api-reference/ometa_api.md
@@ -255,7 +255,21 @@ list_all_entities(
 ) → Iterable[~T]
 ```
 
-Utility method that paginates over all EntityLists to return a generator to fetch entities :param entity: Entity Type, such as Table :param fields: Extra fields to return :param limit: Number of entities in each pagination :param params: Extra parameters, e.g., {"service": "serviceName"} to filter :return: Generator that will be yielding all Entities 
+Utility method that paginates over all EntityLists to return a generator to fetch entities.
+
+**Parameters**:
+
+- `entity`: Entity Type, such as Table
+
+- `fields`: Extra fields to return
+
+- `limit`: Number of entities in each pagination
+
+- `params`: Extra parameters, e.g., {"service": "serviceName"} to filter
+
+**Returns**:
+
+Generator that will be yielding all Entities 
 
 ---
 


### PR DESCRIPTION
## 📘 Summary
This PR edits the Openmetadata docs to be rendered properly in the .md file

## 🔍 Related Issue / Ticket
Fixes open-metadata/OpenMetadata#22823


## ✨ Changes
Changed the `:params` content in the .md docs file for the v1.0.x, v1.8.x, and v1.9.x versions so that they are rendered properly. The `:params` can only work well in a .rst file. And not a .md file

## 🧪 Testing
- [x] Locally built the docs with `yarn dev`
- [x] Verified formatting

## 📸 Screenshots

### Before Code Changes

<img width="1327" height="315" alt="image" src="https://github.com/user-attachments/assets/bfd5faf2-0133-4e69-afe6-d24f4da4844a" />

### After Code Changes

<img width="779" height="290" alt="image" src="https://github.com/user-attachments/assets/53a0d142-c9fe-492f-acdc-e74d483f1801" />
