### PR TITLE
Render param properly

### DIFF
--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/auth_provider.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/auth_provider.md
@@ -70,7 +70,7 @@ Create authentication
 
 **Arguments:**
  
- - <b>`config`</b> (ConfigModel):  configuration 
+ - `config` (ConfigModel):  configuration 
 
 **Returns:**
  AuthenticationProvider 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/client.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/client.md
@@ -80,7 +80,10 @@ Return response status code
 [{% image align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /%}](https://github.com/open-metadata/OpenMetadata/tree/main/ingestion/src/metadata/ingestion/ometa/client.py#L89")
 
 ## class `ClientConfig`
-:param raw_data: should we return api response raw or wrap it with  Entity objects. 
+
+**Args:**
+
+`raw_data`: should we return api response raw or wrap it with  Entity objects. 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/client_utils.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/client_utils.md
@@ -27,13 +27,13 @@ Create an OpenMetadata client
 
 **Args:**
  
- - <b>`metadata_config`</b> (OpenMetadataConnection):  OM connection config 
+ - `metadata_config` (OpenMetadataConnection):  OM connection config 
 
 
 
 **Returns:**
  
- - <b>`OpenMetadata`</b>:  an OM client 
+ - `OpenMetadata`:  an OM client 
 
 
 ---

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/dashboard_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/dashboard_mixin.md
@@ -39,9 +39,13 @@ publish_dashboard_usage(
 ) → None
 ```
 
-POST usage details for a Dashboard 
+POST usage details for a Dashboard
 
-:param dashboard: Table Entity to update :param dashboard_usage_request: Usage data to add 
+**Args:**
+
+`dashboard`: Table Entity to update 
+
+`dashboard_usage_request`: Usage data to add 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/data_insight_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/data_insight_mixin.md
@@ -40,7 +40,7 @@ Given a ReportData object convert it to a json payload and send a POST request t
 
 **Args:**
  
- - <b>`record`</b> (ReportData):  report data 
+ - `record` (ReportData):  report data 
 
 ---
 
@@ -58,7 +58,7 @@ Given a ReportData object convert it to a json payload and send a POST request t
 
 **Args:**
  
- - <b>`record`</b> (ReportData):  report data 
+ - `record` (ReportData):  report data 
 
 ---
 
@@ -104,7 +104,7 @@ Delete report data for a specific report data type
 
 **Args:**
  
- - <b>`report_data_type`</b> (ReportDataType):  report date type to delete 
+ - `report_data_type` (ReportDataType):  report date type to delete 
 
 ---
 
@@ -125,8 +125,8 @@ Delete report data at a specific date for a specific report data type
 
 **Args:**
  
- - <b>`report_data_type`</b> (ReportDataType):  report date type to delete 
- - <b>`date`</b> (str):  date for which to delete the report data 
+ - `report_data_type` (ReportDataType):  report date type to delete 
+ - `date` (str):  date for which to delete the report data 
 
 ---
 
@@ -147,8 +147,8 @@ Deletes web analytics events before a timestamp
 
 **Args:**
  
- - <b>`event_type`</b> (WebAnalyticEventData):  web analytic event type 
- - <b>`tmsp`</b> (int):  timestamp 
+ - `event_type` (WebAnalyticEventData):  web analytic event type 
+ - `tmsp` (int):  timestamp 
 
 ---
 
@@ -172,17 +172,17 @@ _summary_
 
 **Args:**
  
- - <b>`start_ts`</b> (int):  _description_ 
- - <b>`end_ts`</b> (int):  _description_ 
- - <b>`data_insight_chart_name`</b> (str):  _description_ 
- - <b>`data_report_index`</b> (str):  _description_ 
- - <b>`params`</b> (Optional[dict], optional):  _description_. Defaults to None. 
+ - `start_ts` (int):  _description_ 
+ - `end_ts` (int):  _description_ 
+ - `data_insight_chart_name` (str):  _description_ 
+ - `data_report_index` (str):  _description_ 
+ - `params` (Optional[dict], optional):  _description_. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`DataInsightChartResult`</b>:  _description_ 
+ - `DataInsightChartResult`:  _description_ 
 
 ---
 
@@ -204,9 +204,9 @@ Return dict with a list of report data given a start and end date
 
 **Args:**
  
- - <b>`start_ts`</b> (_type_):  start_timestamp 
- - <b>`end_ts`</b> (_type_):  end timestampe 
- - <b>`report_data_type`</b> (ReportDataType):  report data type 
+ - `start_ts` (_type_):  start_timestamp 
+ - `end_ts` (_type_):  end timestampe 
+ - `report_data_type` (ReportDataType):  report data type 
 
 
 
@@ -229,7 +229,7 @@ Given FQN return KPI results
 
 **Args:**
  
- - <b>`fqn`</b> (str):  fullyQualifiedName 
+ - `fqn` (str):  fullyQualifiedName 
 
 ---
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/es_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/es_mixin.md
@@ -51,7 +51,21 @@ es_search_from_fqn(
 
 Given a service_name and some filters, search for entities using ES 
 
-:param entity_type: Entity to look for :param fqn_search_string: string used to search by FQN. E.g., service.*.schema.table :param from_count: Records to expect :param size: Number of records :param fields: Comma separated list of fields to be returned :return: List of entities 
+**Args:**
+
+`entity_type`: Entity to look for 
+
+`fqn_search_string`: string used to search by FQN. E.g., service.*.schema.table 
+
+`from_count`: Records to expect 
+
+`size`: Number of records 
+
+`fields`: Comma separated list of fields to be returned 
+
+**Returns:**
+
+List of entities 
 
 ---
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/index.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/index.md
@@ -50,7 +50,7 @@ slug: /sdk/python/api-reference
 - [`auth_provider.OktaAuthenticationProvider`](/sdk/python/api-reference/auth-provider#class-oktaauthenticationprovider): Prepare the Json Web Token for Okta auth
 - [`auth_provider.OpenMetadataAuthenticationProvider`](/sdk/python/api-reference/auth-provider#class-openmetadataauthenticationprovider): OpenMetadata authentication implementation
 - [`client.APIError`](/sdk/python/api-reference/client#class-apierror): Represent API related error.
-- [`client.ClientConfig`](/sdk/python/api-reference/client#class-clientconfig): :param raw_data: should we return api response raw or wrap it with
+- [`client.ClientConfig`](/sdk/python/api-reference/client#class-clientconfig): Returns api response raw or wrap it with Entity objects
 - [`client.REST`](/sdk/python/api-reference/client#class-rest): REST client wrapper to manage requests with
 - [`client.RetryException`](/sdk/python/api-reference/client#class-retryexception): API Client retry exception
 - [`credentials.DATE`](/sdk/python/api-reference/credentials#class-date): date string in the format YYYY-MM-DD

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/ingestion_pipeline_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/ingestion_pipeline_mixin.md
@@ -39,9 +39,13 @@ create_or_update_pipeline_status(
 ) → None
 ```
 
-PUT create or update pipeline status 
+PUT create or update pipeline status
 
-:param ingestion_pipeline_fqn: Ingestion Pipeline FQN :param pipeline_status: Pipeline Status data to add 
+**Args:**
+
+`ingestion_pipeline_fqn`: Ingestion Pipeline FQN 
+
+`pipeline_status`: Pipeline Status data to add 
 
 ---
 
@@ -62,8 +66,8 @@ Get ingestion pipeline statues based on name
 
 **Args:**
  
- - <b>`name`</b> (str):  Ingestion Pipeline Name 
- - <b>`fields`</b> (List[str]):  List of all the fields 
+ - `name` (str):  Ingestion Pipeline Name 
+ - `fields` (List[str]):  List of all the fields 
 
 ---
 
@@ -78,9 +82,13 @@ get_pipeline_status(
 ) → Optional[PipelineStatus]
 ```
 
-GET pipeline status 
+GET pipeline status
 
-:param ingestion_pipeline_fqn: Ingestion Pipeline FQN :param pipeline_status_run_id: Pipeline Status run id 
+**Args:**
+
+`ingestion_pipeline_fqn`: Ingestion Pipeline FQN 
+
+`pipeline_status_run_id`: Pipeline Status run id 
 
 ---
 
@@ -102,9 +110,9 @@ Get pipeline status between timestamp
 
 **Args:**
  
- - <b>`ingestion_pipeline_fqn`</b> (str):  pipeline fqn 
- - <b>`start_ts`</b> (int):  start_ts 
- - <b>`end_ts`</b> (int):  end_ts 
+ - `ingestion_pipeline_fqn` (str):  pipeline fqn 
+ - `start_ts` (int):  start_ts 
+ - `end_ts` (int):  end_ts 
 
 ---
 
@@ -122,7 +130,7 @@ Run ingestion pipeline workflow
 
 **Args:**
  
- - <b>`ingestion_pipeline_id`</b> (str):  ingestion pipeline uuid 
+ - `ingestion_pipeline_id` (str):  ingestion pipeline uuid 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/lineage_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/lineage_mixin.md
@@ -86,7 +86,17 @@ get_lineage_by_id(
 ) → Optional[Dict[str, Any]]
 ```
 
-Get lineage details for an entity `id` :param entity: Type of the entity :param entity_id: Entity ID :param up_depth: Upstream depth of lineage (default=1, min=0, max=3)" :param down_depth: Downstream depth of lineage (default=1, min=0, max=3) 
+Get lineage details for an entity `id` 
+
+**Args:**
+
+`entity`: Type of the entity 
+
+`entity_id`: Entity ID 
+
+`up_depth`: Upstream depth of lineage (default=1, min=0, max=3)" 
+
+`down_depth`: Downstream depth of lineage (default=1, min=0, max=3) 
 
 ---
 
@@ -103,7 +113,17 @@ get_lineage_by_name(
 ) → Optional[Dict[str, Any]]
 ```
 
-Get lineage details for an entity `id` :param entity: Type of the entity :param fqn: Entity FQN :param up_depth: Upstream depth of lineage (default=1, min=0, max=3)" :param down_depth: Downstream depth of lineage (default=1, min=0, max=3) 
+Get lineage details for an entity `id` 
+
+**Args:**
+
+`entity`: Type of the entity 
+
+`fqn`: Entity FQN 
+
+`up_depth`: Upstream depth of lineage (default=1, min=0, max=3)" 
+
+`down_depth`: Downstream depth of lineage (default=1, min=0, max=3) 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/mlmodel_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/mlmodel_mixin.md
@@ -39,7 +39,17 @@ add_mlmodel_lineage(
 ) → Dict[str, Any]
 ```
 
-Iterates over MlModel's Feature Sources and add the lineage information. :param model: MlModel containing EntityReferences :param description: Lineage description :return: List of added lineage information 
+Iterates over MlModel's Feature Sources and add the lineage information. 
+
+**Args:**
+
+`model`: MlModel containing EntityReferences 
+
+`description`: Lineage description 
+
+**Returns:**
+
+List of added lineage information 
 
 ---
 
@@ -58,7 +68,21 @@ get_mlmodel_sklearn(
 
 Get an MlModel Entity instance from a scikit-learn model. 
 
-Sklearn estimators all extend BaseEstimator. :param name: MlModel name :param model: sklearn estimator :param description: MlModel description :param service_name: Service name to use when creating sklearn service :return: OpenMetadata CreateMlModelRequest Entity 
+Sklearn estimators all extend BaseEstimator. 
+
+**Args:**
+
+`name`: MlModel name 
+
+`model`: sklearn estimator 
+
+`description`: MlModel description 
+
+`service_name`: Service name to use when creating sklearn service 
+
+**Returns:**
+
+OpenMetadata CreateMlModelRequest Entity 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/ometa_api.md
@@ -201,7 +201,17 @@ Inversely, import the Entity type based on the create Entity class
 get_entity_reference(entity: Type[~T], fqn: str) → Optional[EntityReference]
 ```
 
-Helper method to obtain an EntityReference from a FQN and the Entity class. :param entity: Entity Class :param fqn: Entity instance FQN :return: EntityReference or None 
+Helper method to obtain an EntityReference from a FQN and the Entity class. 
+
+**Args:**
+
+`entity`: Entity Class 
+
+`fqn`: Entity instance FQN 
+
+**Returns:**
+
+EntityReference or None 
 
 ---
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/ometa_api.md
@@ -255,7 +255,21 @@ list_all_entities(
 ) → Iterable[~T]
 ```
 
-Utility method that paginates over all EntityLists to return a generator to fetch entities :param entity: Entity Type, such as Table :param fields: Extra fields to return :param limit: Number of entities in each pagination :param params: Extra parameters, e.g., {"service": "serviceName"} to filter :return: Generator that will be yielding all Entities 
+Utility method that paginates over all EntityLists to return a generator to fetch entities 
+
+**Parameters**:
+
+- `entity`: Entity Type, such as Table
+
+- `fields`: Extra fields to return
+
+- `limit`: Number of entities in each pagination
+
+- `params`: Extra parameters, e.g., {"service": "serviceName"} to filter
+
+**Returns**:
+
+Generator that will be yielding all Entities 
 
 ---
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/patch_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/patch_mixin.md
@@ -190,9 +190,13 @@ Patch domain data for an Entity
 patch_life_cycle(entity: BaseModel, life_cycle: LifeCycle) → Optional[BaseModel]
 ```
 
-Patch life cycle data for a entity 
+Patch life cycle data for a entity
 
-:param entity: Entity to update the life cycle for :param life_cycle_data: Life Cycle data to add 
+**Args:**
+
+`entity`: Entity to update the life cycle for 
+
+`life_cycle_data`: Life Cycle data to add 
 
 ---
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/patch_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/patch_mixin.md
@@ -75,9 +75,17 @@ patch(entity: Type[~T], source: ~T, destination: ~T) → Optional[~T]
 
 Given an Entity type and Source entity and Destination entity, generate a JSON Patch and apply it. 
 
-Args  entity (T): Entity Type  source: Source payload which is current state of the source in OpenMetadata  destination: payload with changes applied to the source. 
+**Args:**  
 
-Returns  Updated Entity 
+`entity` (T): Entity Type  
+
+`source`: Source payload which is current state of the source in OpenMetadata  
+
+`destination`: payload with changes applied to the source. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -112,7 +120,19 @@ patch_column_description(
 
 Given an Table , Column FQN, JSON PATCH the description of the column 
 
-Args  src_table: origin Table object  column_fqn: FQN of the column to update  description: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`src_table`: origin Table object  
+
+`column_fqn`: FQN of the column to update  
+
+`description`: new description to add  
+
+`force`: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -147,7 +167,19 @@ patch_column_tags(
 
 Given an Entity ID, JSON PATCH the tag of the column 
 
-Args  entity_id: ID  tag_label: TagLabel to add or remove  column_name: column to update  operation: Patch Operation to add or remove Returns  Updated Entity 
+**Args:**  
+
+`entity_id`: ID  
+
+`tag_label`: TagLabel to add or remove  
+
+`column_name`: column to update  
+
+`operation`: Patch Operation to add or remove 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -166,7 +198,19 @@ patch_description(
 
 Given an Entity type and ID, JSON PATCH the description. 
 
-Args  entity (T): Entity Type  source: source entity object  description: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`entity` (T): Entity Type  
+
+`source`: source entity object  
+
+`description`: new description to add  
+
+`force`: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -215,7 +259,19 @@ patch_owner(
 
 Given an Entity type and ID, JSON PATCH the owner. If not owner Entity type and not owner ID are provided, the owner is removed. 
 
-Args  entity (T): Entity Type of the entity to be patched  entity_id: ID of the entity to be patched  owner: Entity Reference of the owner. If None, the owner will be removed  force: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`entity` (T): Entity Type of the entity to be patched  
+
+`entity_id`: ID of the entity to be patched  
+
+`owner`: Entity Reference of the owner. If None, the owner will be removed  
+
+`force`: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -232,9 +288,17 @@ patch_table_constraints(
 
 Given an Entity ID, JSON PATCH the table constraints of table 
 
-Args  source_table: Origin table  description: new description to add  table_constraints: table constraints to add 
+**Args:**  
 
-Returns  Updated Entity 
+`source_table`: Origin table  
+
+`description`: new description to add  
+
+`table_constraints`: table constraints to add 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -270,7 +334,19 @@ patch_tags(
 
 Given an Entity type and ID, JSON PATCH the tag. 
 
-Args  entity (T): Entity Type  source: Source entity object  tag_label: TagLabel to add or remove  operation: Patch Operation to add or remove the tag. Returns  Updated Entity 
+**Args:**  
+
+`entity` (T): Entity Type  
+
+`source`: Source entity object  
+
+`tag_label`: TagLabel to add or remove  
+
+`operation`: Patch Operation to add or remove the tag. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -288,7 +364,11 @@ patch_test_case_definition(
 
 Given a test case and a test case definition JSON PATCH the test case 
 
-Args  test_case: test case object  test_case_definition: test case definition to add 
+**Args:**  
+
+`test_case`: test case object  
+
+`test_case_definition`: test case definition to add 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/query_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/query_mixin.md
@@ -69,9 +69,13 @@ ingest_entity_queries_data(
 ) → None
 ```
 
-PUT queries for an entity 
+PUT queries for an entity
 
-:param entity: Entity to update :param queries: CreateQueryRequest to add 
+**Args:**
+
+`entity`: Entity to update 
+
+`queries`: CreateQueryRequest to add 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/query_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/query_mixin.md
@@ -45,8 +45,8 @@ Get the queries attached to a table
 
 **Args:**
  
- - <b>`entity_id`</b> (Union[Uuid,str]):  entity id of given entity 
- - <b>`fields`</b> (Optional[List[str]]):  list of fields to be included in response 
+ - `entity_id` (Union[Uuid,str]):  entity id of given entity 
+ - `fields` (Optional[List[str]]):  list of fields to be included in response 
 
 
 
@@ -54,7 +54,7 @@ Get the queries attached to a table
 
 **Returns:**
  
- - <b>`Optional[List[Query]]`</b>:  List of queries 
+ - `Optional[List[Query]]`:  List of queries 
 
 ---
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/search_index_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/search_index_mixin.md
@@ -41,7 +41,11 @@ ingest_search_index_sample_data(
 
 PUT sample data for a search index 
 
-:param search_index: SearchIndex Entity to update :param sample_data: Data to add 
+**Args:**
+
+`search_index`: SearchIndex Entity to update
+
+`sample_data`: Data to add 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/service_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/service_mixin.md
@@ -39,9 +39,17 @@ Create a service of type T.
 We need to extract from the WorkflowSource: 
 - name: serviceName 
 - serviceType: Type Enum 
-- connection: (DatabaseConnection, DashboardConnection...) 
+- connection: (DatabaseConnection, DashboardConnection...)
 
-:param entity: Service Type :param config: WorkflowSource :return: Created Service 
+**Args:**
+
+`entity`: Service Type 
+
+`config`: WorkflowSource 
+
+**Returns:**
+
+Created Service 
 
 ---
 
@@ -53,7 +61,17 @@ We need to extract from the WorkflowSource:
 get_create_service_from_source(entity: Type[~T], config: Source) → ~C
 ```
 
-Prepare a CreateService request from source config :param entity: Service Type :param config: WorkflowSource :return: CreateService request 
+Prepare a CreateService request from source config 
+
+**Args:**
+
+`entity`: Service Type 
+
+`config`: WorkflowSource 
+
+**Returns:**
+
+CreateService request 
 
 If the OpenMetadata Connection has storeServiceConnection set to false, we won't pass the connection details when creating the service. 
 
@@ -67,7 +85,17 @@ If the OpenMetadata Connection has storeServiceConnection set to false, we won't
 get_service_or_create(entity: Type[~T], config: Source) → ~T
 ```
 
-Fetches a service by name, or creates it using the WorkflowSource config :param entity: Entity Type to get or create :param config: WorkflowSource :return: Entity Service of T 
+Fetches a service by name, or creates it using the WorkflowSource config
+
+**Args:**
+
+`entity`: Entity Type to get or create 
+
+`config`: WorkflowSource 
+
+**Returns:**
+
+Entity Service of T 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/table_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/table_mixin.md
@@ -63,9 +63,17 @@ create_or_update_table_profiler_config(
 ) → Optional[Table]
 ```
 
-Update the profileSample property of a Table, given its FQN. 
+Update the profileSample property of a Table, given its FQN.
 
-:param fqn: Table FQN :param profile_sample: new profile sample to set :return: Updated table 
+**Args:**
+
+`fqn`: Table FQN 
+
+`profile_sample`: new profile sample to set 
+
+**Returns:**
+
+Updated table 
 
 ---
 
@@ -159,9 +167,13 @@ ingest_profile_data(
 ) → Table
 ```
 
-PUT profile data for a table 
+PUT profile data for a table
 
-:param table: Table Entity to update :param table_profile: Profile data to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`table_profile`: Profile data to add 
 
 ---
 
@@ -173,9 +185,13 @@ PUT profile data for a table
 ingest_table_data_model(table: Table, data_model: DataModel) → Table
 ```
 
-PUT data model for a table 
+PUT data model for a table
 
-:param table: Table Entity to update :param data_model: Model to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`data_model`: Model to add 
 
 ---
 
@@ -190,9 +206,13 @@ ingest_table_sample_data(
 ) → Optional[TableData]
 ```
 
-PUT sample data for a table 
+PUT sample data for a table
 
-:param table: Table Entity to update :param sample_data: Data to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`sample_data`: Data to add 
 
 ---
 
@@ -207,9 +227,13 @@ publish_frequently_joined_with(
 ) → None
 ```
 
-POST frequently joined with for a table 
+POST frequently joined with for a table
 
-:param table: Table Entity to update :param table_join_request: Join data to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`table_join_request`: Join data to add 
 
 ---
 
@@ -221,9 +245,13 @@ POST frequently joined with for a table
 publish_table_usage(table: Table, table_usage_request: UsageRequest) → None
 ```
 
-POST usage details for a Table 
+POST usage details for a Table
 
-:param table: Table Entity to update :param table_usage_request: Usage data to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`table_usage_request`: Usage data to add 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/table_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/table_mixin.md
@@ -48,7 +48,7 @@ Create or update custom metric. If custom metric name matches an existing one th
 
 **Args:**
  
- - <b>`custom_metric`</b> (CreateCustomMetricRequest):  custom metric to be create or updated 
+ - `custom_metric` (CreateCustomMetricRequest):  custom metric to be create or updated 
 
 ---
 
@@ -91,13 +91,13 @@ Get the latest profile data for a table
 
 **Args:**
  
- - <b>`fqn`</b> (str):  table fully qualified name 
+ - `fqn` (str):  table fully qualified name 
 
 
 
 **Returns:**
  
- - <b>`Optional[Table]`</b>:  OM table object 
+ - `Optional[Table]`:  OM table object 
 
 ---
 
@@ -122,23 +122,23 @@ Get profile data
 
 **Args:**
  
- - <b>`fqn`</b> (str):  fullyQualifiedName 
- - <b>`start_ts`</b> (int):  start timestamp 
- - <b>`end_ts`</b> (int):  end timestamp 
- - <b>`limit`</b> (int, optional):  limit of record to return. Defaults to 100. 
- - <b>`after`</b> (_type_, optional):  use for API pagination. Defaults to None. profile_type (Union[Type[TableProfile], Type[ColumnProfile]], optional):  Profile type to retrieve. Defaults to TableProfile. 
+ - `fqn` (str):  fullyQualifiedName 
+ - `start_ts` (int):  start timestamp 
+ - `end_ts` (int):  end timestamp 
+ - `limit` (int, optional):  limit of record to return. Defaults to 100. 
+ - `after` (_type_, optional):  use for API pagination. Defaults to None. profile_type (Union[Type[TableProfile], Type[ColumnProfile]], optional):  Profile type to retrieve. Defaults to TableProfile. 
 
 
 
 **Raises:**
  
- - <b>`TypeError`</b>:  if `profile_type` is not TableProfile or ColumnProfile 
+ - `TypeError`:  if `profile_type` is not TableProfile or ColumnProfile 
 
 
 
 **Returns:**
  
- - <b>`EntityList`</b>:  EntityList list object 
+ - `EntityList`:  EntityList list object 
 
 ---
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/tests_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/tests_mixin.md
@@ -42,7 +42,7 @@ Add logical test cases to a test suite
 
 **Args:**
  
- - <b>`data`</b> (CreateLogicalTestCases):  logical test cases 
+ - `data` (CreateLogicalTestCases):  logical test cases 
 
 ---
 
@@ -60,14 +60,14 @@ Add test case results to a test case
 
 **Args:**
  
- - <b>`test_results`</b> (TestCaseResult):  test case results to pass to the test case 
- - <b>`test_case_fqn`</b> (str):  test case fqn 
+ - `test_results` (TestCaseResult):  test case results to pass to the test case 
+ - `test_case_fqn` (str):  test case fqn 
 
 
 
 **Returns:**
  
- - <b>`_type_`</b>:  _description_ 
+ - `_type_`:  _description_ 
 
 ---
 
@@ -85,13 +85,13 @@ Create or update an executable test suite
 
 **Args:**
  
- - <b>`data`</b> (CreateTestSuiteRequest):  test suite request 
+ - `data` (CreateTestSuiteRequest):  test suite request 
 
 
 
 **Returns:**
  
- - <b>`TestSuite`</b>:  test suite object 
+ - `TestSuite`:  test suite object 
 
 ---
 
@@ -114,9 +114,9 @@ Delete executable test suite
 
 **Args:**
  
- - <b>`entity_id`</b> (str):  test suite ID 
- - <b>`recursive`</b> (bool, optional):  delete children if true 
- - <b>`hard_delete`</b> (bool, optional):  hard delete if true 
+ - `entity_id` (str):  test suite ID 
+ - `recursive` (bool, optional):  delete children if true 
+ - `hard_delete` (bool, optional):  hard delete if true 
 
 ---
 
@@ -136,7 +136,7 @@ Given an entity fqn, retrieve the link test suite if it exists or create a new o
 
 **Args:**
  
- - <b>`table_fqn`</b> (str):  entity fully qualified name 
+ - `table_fqn` (str):  entity fully qualified name 
 
 
 
@@ -164,17 +164,17 @@ Get or create a test case
 
 **Args:**
  
- - <b>`test_case_fqn`</b> (str):  fully qualified name for the test 
- - <b>`entity_link`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_suite_fqn`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_definition_fqn`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_case_parameter_values`</b> (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_case_fqn` (str):  fully qualified name for the test 
+ - `entity_link` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_suite_fqn` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_definition_fqn` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_case_parameter_values` (Optional[str], optional):  _description_. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`_type_`</b>:  _description_ 
+ - `_type_`:  _description_ 
 
 ---
 
@@ -198,17 +198,17 @@ Get or create a test definition
 
 **Args:**
  
- - <b>`test_definition_fqn`</b> (str):  test definition fully qualified name 
- - <b>`test_definition_description`</b> (Optional[str], optional):  description for the test definition.  Defaults to None. 
- - <b>`entity_type`</b> (Optional[EntityType], optional):  entity type (COLUMN or TABLE). Defaults to None. 
- - <b>`test_platforms`</b> (Optional[List[TestPlatform]], optional):  test platforms. Defaults to None. 
- - <b>`test_case_parameter_definition`</b> (Optional[List[TestCaseParameterDefinition]], optional):  parameters for the  test case definition. Defaults to None. 
+ - `test_definition_fqn` (str):  test definition fully qualified name 
+ - `test_definition_description` (Optional[str], optional):  description for the test definition.  Defaults to None. 
+ - `entity_type` (Optional[EntityType], optional):  entity type (COLUMN or TABLE). Defaults to None. 
+ - `test_platforms` (Optional[List[TestPlatform]], optional):  test platforms. Defaults to None. 
+ - `test_case_parameter_definition` (Optional[List[TestCaseParameterDefinition]], optional):  parameters for the  test case definition. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`TestDefinition`</b>:  a test definition object 
+ - `TestDefinition`:  a test definition object 
 
 ---
 
@@ -229,8 +229,8 @@ Get or create a TestSuite
 
 **Args:**
  
- - <b>`test_suite_name`</b> (str):  test suite name 
- - <b>`test_suite_description`</b> (Optional[str], optional):  test suite description.  Defaults to f"Test Suite created on {datetime.now(timezone.utc).strftime('%Y-%m-%d')}". 
+ - `test_suite_name` (str):  test suite name 
+ - `test_suite_description` (Optional[str], optional):  test suite description.  Defaults to f"Test Suite created on {datetime.now(timezone.utc).strftime('%Y-%m-%d')}". 
 
 
 
@@ -257,9 +257,9 @@ Retrieve list of test cases
 
 **Args:**
  
- - <b>`test_case_fqn`</b> (str):  test_case_fqn 
- - <b>`start_ts`</b> (int):  timestamp 
- - <b>`end_ts`</b> (int):  timestamp 
+ - `test_case_fqn` (str):  test_case_fqn 
+ - `start_ts` (int):  timestamp 
+ - `end_ts` (int):  timestamp 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/topic_mixin.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/topic_mixin.md
@@ -39,9 +39,13 @@ ingest_topic_sample_data(
 ) → TopicSampleData
 ```
 
-PUT sample data for a topic 
+PUT sample data for a topic
 
-:param topic: Topic Entity to update :param sample_data: Data to add 
+**Args:**
+
+`topic`: Topic Entity to update 
+
+`sample_data`: Data to add 
 
 
 

--- a/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/utils.md
+++ b/content/v1.10.x-SNAPSHOT/sdk/python/api-reference/utils.md
@@ -21,7 +21,15 @@ Helper functions to handle OpenMetadata Entities' properties
 format_name(name: str) → str
 ```
 
-Given a name, replace all special characters by `_` :param name: name to format :return: formatted string 
+Given a name, replace all special characters by `_` 
+
+**Args:**
+
+`name`: name to format 
+
+**Returns:**
+
+formatted string 
 
 
 ---

--- a/content/v1.8.x/sdk/python/api-reference/auth_provider.md
+++ b/content/v1.8.x/sdk/python/api-reference/auth_provider.md
@@ -70,7 +70,7 @@ Create authentication
 
 **Arguments:**
  
- - <b>`config`</b> (ConfigModel):  configuration 
+ - `config` (ConfigModel):  configuration
 
 **Returns:**
  AuthenticationProvider 

--- a/content/v1.8.x/sdk/python/api-reference/client.md
+++ b/content/v1.8.x/sdk/python/api-reference/client.md
@@ -80,7 +80,10 @@ Return response status code
 [{% image align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /%}](https://github.com/open-metadata/OpenMetadata/tree/main/ingestion/src/metadata/ingestion/ometa/client.py#L89")
 
 ## class `ClientConfig`
-:param raw_data: should we return api response raw or wrap it with  Entity objects. 
+
+**Args:**
+
+`raw_data`: should we return api response raw or wrap it with  Entity objects. 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/client_utils.md
+++ b/content/v1.8.x/sdk/python/api-reference/client_utils.md
@@ -27,13 +27,13 @@ Create an OpenMetadata client
 
 **Args:**
  
- - <b>`metadata_config`</b> (OpenMetadataConnection):  OM connection config 
+ - `metadata_config` (OpenMetadataConnection):  OM connection config 
 
 
 
 **Returns:**
  
- - <b>`OpenMetadata`</b>:  an OM client 
+ - `OpenMetadata`:  an OM client 
 
 
 ---

--- a/content/v1.8.x/sdk/python/api-reference/dashboard_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/dashboard_mixin.md
@@ -39,9 +39,13 @@ publish_dashboard_usage(
 ) → None
 ```
 
-POST usage details for a Dashboard 
+POST usage details for a Dashboard
 
-:param dashboard: Table Entity to update :param dashboard_usage_request: Usage data to add 
+**Args:**
+
+`dashboard`: Table Entity to update 
+
+`dashboard_usage_request`: Usage data to add 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/data_insight_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/data_insight_mixin.md
@@ -40,7 +40,7 @@ Given a ReportData object convert it to a json payload and send a POST request t
 
 **Args:**
  
- - <b>`record`</b> (ReportData):  report data 
+ - `record` (ReportData):  report data 
 
 ---
 
@@ -58,7 +58,7 @@ Given a ReportData object convert it to a json payload and send a POST request t
 
 **Args:**
  
- - <b>`record`</b> (ReportData):  report data 
+ - `record` (ReportData):  report data 
 
 ---
 
@@ -104,7 +104,7 @@ Delete report data for a specific report data type
 
 **Args:**
  
- - <b>`report_data_type`</b> (ReportDataType):  report date type to delete 
+ - `report_data_type` (ReportDataType):  report date type to delete 
 
 ---
 
@@ -125,8 +125,8 @@ Delete report data at a specific date for a specific report data type
 
 **Args:**
  
- - <b>`report_data_type`</b> (ReportDataType):  report date type to delete 
- - <b>`date`</b> (str):  date for which to delete the report data 
+ - `report_data_type` (ReportDataType):  report date type to delete 
+ - `date` (str):  date for which to delete the report data 
 
 ---
 
@@ -147,8 +147,8 @@ Deletes web analytics events before a timestamp
 
 **Args:**
  
- - <b>`event_type`</b> (WebAnalyticEventData):  web analytic event type 
- - <b>`tmsp`</b> (int):  timestamp 
+ - `event_type` (WebAnalyticEventData):  web analytic event type 
+ - `tmsp` (int):  timestamp 
 
 ---
 
@@ -172,17 +172,17 @@ _summary_
 
 **Args:**
  
- - <b>`start_ts`</b> (int):  _description_ 
- - <b>`end_ts`</b> (int):  _description_ 
- - <b>`data_insight_chart_name`</b> (str):  _description_ 
- - <b>`data_report_index`</b> (str):  _description_ 
- - <b>`params`</b> (Optional[dict], optional):  _description_. Defaults to None. 
+ - `start_ts` (int):  _description_ 
+ - `end_ts` (int):  _description_ 
+ - `data_insight_chart_name` (str):  _description_ 
+ - `data_report_index` (str):  _description_ 
+ - `params` (Optional[dict], optional):  _description_. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`DataInsightChartResult`</b>:  _description_ 
+ - `DataInsightChartResult`:  _description_ 
 
 ---
 
@@ -204,9 +204,9 @@ Return dict with a list of report data given a start and end date
 
 **Args:**
  
- - <b>`start_ts`</b> (_type_):  start_timestamp 
- - <b>`end_ts`</b> (_type_):  end timestampe 
- - <b>`report_data_type`</b> (ReportDataType):  report data type 
+ - `start_ts` (_type_):  start_timestamp 
+ - `end_ts` (_type_):  end timestampe 
+ - `report_data_type` (ReportDataType):  report data type 
 
 
 
@@ -229,7 +229,7 @@ Given FQN return KPI results
 
 **Args:**
  
- - <b>`fqn`</b> (str):  fullyQualifiedName 
+ - `fqn` (str):  fullyQualifiedName 
 
 ---
 

--- a/content/v1.8.x/sdk/python/api-reference/es_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/es_mixin.md
@@ -49,9 +49,19 @@ es_search_from_fqn(
 ) → Optional[List[~T]]
 ```
 
-Given a service_name and some filters, search for entities using ES 
+Given a service_name and some filters, search for entities using ES
 
-:param entity_type: Entity to look for :param fqn_search_string: string used to search by FQN. E.g., service.*.schema.table :param from_count: Records to expect :param size: Number of records :param fields: Comma separated list of fields to be returned :return: List of entities 
+**Args:**
+
+`entity_type`: Entity to look for 
+
+`fqn_search_string`: string used to search by FQN. E.g., service.*.schema.table 
+
+`from_count`: Records to expect 
+
+`size`: Number of records 
+
+`fields`: Comma separated list of fields to be returned :return: List of entities 
 
 ---
 

--- a/content/v1.8.x/sdk/python/api-reference/index.md
+++ b/content/v1.8.x/sdk/python/api-reference/index.md
@@ -50,7 +50,7 @@ slug: /sdk/python/api-reference
 - [`auth_provider.OktaAuthenticationProvider`](/sdk/python/api-reference/auth-provider#class-oktaauthenticationprovider): Prepare the Json Web Token for Okta auth
 - [`auth_provider.OpenMetadataAuthenticationProvider`](/sdk/python/api-reference/auth-provider#class-openmetadataauthenticationprovider): OpenMetadata authentication implementation
 - [`client.APIError`](/sdk/python/api-reference/client#class-apierror): Represent API related error.
-- [`client.ClientConfig`](/sdk/python/api-reference/client#class-clientconfig): :param raw_data: should we return api response raw or wrap it with
+- [`client.ClientConfig`](/sdk/python/api-reference/client#class-clientconfig): Returns api response raw or wrap it with Entity objects
 - [`client.REST`](/sdk/python/api-reference/client#class-rest): REST client wrapper to manage requests with
 - [`client.RetryException`](/sdk/python/api-reference/client#class-retryexception): API Client retry exception
 - [`credentials.DATE`](/sdk/python/api-reference/credentials#class-date): date string in the format YYYY-MM-DD

--- a/content/v1.8.x/sdk/python/api-reference/ingestion_pipeline_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/ingestion_pipeline_mixin.md
@@ -39,9 +39,13 @@ create_or_update_pipeline_status(
 ) → None
 ```
 
-PUT create or update pipeline status 
+PUT create or update pipeline status
 
-:param ingestion_pipeline_fqn: Ingestion Pipeline FQN :param pipeline_status: Pipeline Status data to add 
+**Args:**
+
+`ingestion_pipeline_fqn`: Ingestion Pipeline FQN 
+
+`pipeline_status`: Pipeline Status data to add 
 
 ---
 
@@ -62,8 +66,8 @@ Get ingestion pipeline statues based on name
 
 **Args:**
  
- - <b>`name`</b> (str):  Ingestion Pipeline Name 
- - <b>`fields`</b> (List[str]):  List of all the fields 
+ - `name` (str):  Ingestion Pipeline Name 
+ - `fields` (List[str]):  List of all the fields 
 
 ---
 
@@ -78,9 +82,13 @@ get_pipeline_status(
 ) → Optional[PipelineStatus]
 ```
 
-GET pipeline status 
+GET pipeline status
 
-:param ingestion_pipeline_fqn: Ingestion Pipeline FQN :param pipeline_status_run_id: Pipeline Status run id 
+**Args:**
+
+`ingestion_pipeline_fqn`: Ingestion Pipeline FQN 
+
+`pipeline_status_run_id`: Pipeline Status run id 
 
 ---
 
@@ -102,9 +110,9 @@ Get pipeline status between timestamp
 
 **Args:**
  
- - <b>`ingestion_pipeline_fqn`</b> (str):  pipeline fqn 
- - <b>`start_ts`</b> (int):  start_ts 
- - <b>`end_ts`</b> (int):  end_ts 
+ - `ingestion_pipeline_fqn` (str):  pipeline fqn 
+ - `start_ts` (int):  start_ts 
+ - `end_ts` (int):  end_ts 
 
 ---
 
@@ -122,7 +130,7 @@ Run ingestion pipeline workflow
 
 **Args:**
  
- - <b>`ingestion_pipeline_id`</b> (str):  ingestion pipeline uuid 
+ - `ingestion_pipeline_id` (str):  ingestion pipeline uuid 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/lineage_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/lineage_mixin.md
@@ -86,7 +86,17 @@ get_lineage_by_id(
 ) → Optional[Dict[str, Any]]
 ```
 
-Get lineage details for an entity `id` :param entity: Type of the entity :param entity_id: Entity ID :param up_depth: Upstream depth of lineage (default=1, min=0, max=3)" :param down_depth: Downstream depth of lineage (default=1, min=0, max=3) 
+Get lineage details for an entity `id` 
+
+**Args:**
+
+`entity`: Type of the entity 
+
+`entity_id`: Entity ID 
+
+`up_depth`: Upstream depth of lineage (default=1, min=0, max=3)" 
+
+`down_depth`: Downstream depth of lineage (default=1, min=0, max=3) 
 
 ---
 
@@ -103,7 +113,17 @@ get_lineage_by_name(
 ) → Optional[Dict[str, Any]]
 ```
 
-Get lineage details for an entity `id` :param entity: Type of the entity :param fqn: Entity FQN :param up_depth: Upstream depth of lineage (default=1, min=0, max=3)" :param down_depth: Downstream depth of lineage (default=1, min=0, max=3) 
+Get lineage details for an entity `id` 
+
+**Args:**
+
+`entity`: Type of the entity 
+
+`fqn`: Entity FQN 
+
+`up_depth`: Upstream depth of lineage (default=1, min=0, max=3)" 
+
+`down_depth`: Downstream depth of lineage (default=1, min=0, max=3) 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/mlmodel_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/mlmodel_mixin.md
@@ -39,7 +39,17 @@ add_mlmodel_lineage(
 ) → Dict[str, Any]
 ```
 
-Iterates over MlModel's Feature Sources and add the lineage information. :param model: MlModel containing EntityReferences :param description: Lineage description :return: List of added lineage information 
+Iterates over MlModel's Feature Sources and add the lineage information. 
+
+**Args:**
+
+`model`: MlModel containing EntityReferences 
+
+`description`: Lineage description 
+
+**Returns:**
+
+List of added lineage information 
 
 ---
 
@@ -58,7 +68,21 @@ get_mlmodel_sklearn(
 
 Get an MlModel Entity instance from a scikit-learn model. 
 
-Sklearn estimators all extend BaseEstimator. :param name: MlModel name :param model: sklearn estimator :param description: MlModel description :param service_name: Service name to use when creating sklearn service :return: OpenMetadata CreateMlModelRequest Entity 
+Sklearn estimators all extend BaseEstimator. 
+
+**Args:**
+
+`name`: MlModel name 
+
+`model`: sklearn estimator 
+
+`description`: MlModel description 
+
+`service_name`: Service name to use when creating sklearn service 
+
+**Returns:**
+
+OpenMetadata CreateMlModelRequest Entity 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.8.x/sdk/python/api-reference/ometa_api.md
@@ -131,7 +131,11 @@ delete(
 
 API call to delete an entity from entity ID 
 
-Args  entity (T): entity Type  entity_id (basic.Uuid): entity ID Returns  None 
+**Args:**  
+
+`entity` (T): entity Type  
+
+`entity_id` (basic.Uuid): entity ID Returns  None 
 
 ---
 
@@ -201,7 +205,17 @@ Inversely, import the Entity type based on the create Entity class
 get_entity_reference(entity: Type[~T], fqn: str) → Optional[EntityReference]
 ```
 
-Helper method to obtain an EntityReference from a FQN and the Entity class. :param entity: Entity Class :param fqn: Entity instance FQN :return: EntityReference or None 
+Helper method to obtain an EntityReference from a FQN and the Entity class. 
+
+**Args:**
+
+`entity`: Entity Class 
+
+`fqn`: Entity instance FQN 
+
+**Returns:**
+
+EntityReference or None 
 
 ---
 

--- a/content/v1.8.x/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.8.x/sdk/python/api-reference/ometa_api.md
@@ -255,7 +255,21 @@ list_all_entities(
 ) → Iterable[~T]
 ```
 
-Utility method that paginates over all EntityLists to return a generator to fetch entities :param entity: Entity Type, such as Table :param fields: Extra fields to return :param limit: Number of entities in each pagination :param params: Extra parameters, e.g., {"service": "serviceName"} to filter :return: Generator that will be yielding all Entities 
+Utility method that paginates over all EntityLists to return a generator to fetch entities 
+
+**Parameters**:
+
+- `entity`: Entity Type, such as Table
+
+- `fields`: Extra fields to return
+
+- `limit`: Number of entities in each pagination
+
+- `params`: Extra parameters, e.g., {"service": "serviceName"} to filter
+
+**Returns**:
+
+Generator that will be yielding all Entities 
 
 ---
 

--- a/content/v1.8.x/sdk/python/api-reference/patch_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/patch_mixin.md
@@ -75,9 +75,17 @@ patch(entity: Type[~T], source: ~T, destination: ~T) → Optional[~T]
 
 Given an Entity type and Source entity and Destination entity, generate a JSON Patch and apply it. 
 
-Args  entity (T): Entity Type  source: Source payload which is current state of the source in OpenMetadata  destination: payload with changes applied to the source. 
+**Args:**
 
-Returns  Updated Entity 
+`entity (T)`: Entity Type  
+
+`source`: Source payload which is current state of the source in OpenMetadata  
+
+`destination`: payload with changes applied to the source. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -112,7 +120,19 @@ patch_column_description(
 
 Given an Table , Column FQN, JSON PATCH the description of the column 
 
-Args  src_table: origin Table object  column_fqn: FQN of the column to update  description: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`src_table`: origin Table object  
+
+`column_fqn`: FQN of the column to update  
+
+`description`: new description to add  
+
+`force`: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -147,7 +167,19 @@ patch_column_tags(
 
 Given an Entity ID, JSON PATCH the tag of the column 
 
-Args  entity_id: ID  tag_label: TagLabel to add or remove  column_name: column to update  operation: Patch Operation to add or remove Returns  Updated Entity 
+**Args:**  
+
+`entity_id`: ID  
+
+`tag_label`: TagLabel to add or remove  
+
+`column_name`: column to update  
+
+`operation`: Patch Operation to add or remove 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -166,7 +198,19 @@ patch_description(
 
 Given an Entity type and ID, JSON PATCH the description. 
 
-Args  entity (T): Entity Type  source: source entity object  description: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`entity (T)`: Entity Type  
+
+`source`: source entity object  
+
+`description`: new description to add  
+
+`force`: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -190,9 +234,13 @@ Patch domain data for an Entity
 patch_life_cycle(entity: BaseModel, life_cycle: LifeCycle) → Optional[BaseModel]
 ```
 
-Patch life cycle data for a entity 
+Patch life cycle data for a entity
 
-:param entity: Entity to update the life cycle for :param life_cycle_data: Life Cycle data to add 
+**Args:**
+
+`entity`: Entity to update the life cycle for 
+
+`life_cycle_data`: Life Cycle data to add 
 
 ---
 
@@ -211,7 +259,17 @@ patch_owner(
 
 Given an Entity type and ID, JSON PATCH the owner. If not owner Entity type and not owner ID are provided, the owner is removed. 
 
-Args  entity (T): Entity Type of the entity to be patched  entity_id: ID of the entity to be patched  owner: Entity Reference of the owner. If None, the owner will be removed  force: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`entity (T)`: Entity Type of the entity to be patched  
+
+`entity_id`: ID of the entity to be patched  
+
+`owner`: Entity Reference of the owner. If None, the owner will be removed  force: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -228,9 +286,17 @@ patch_table_constraints(
 
 Given an Entity ID, JSON PATCH the table constraints of table 
 
-Args  source_table: Origin table  description: new description to add  table_constraints: table constraints to add 
+**Args:**  
 
-Returns  Updated Entity 
+`source_table`: Origin table  
+
+`description`: new description to add  
+
+`table_constraints`: table constraints to add 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -266,7 +332,19 @@ patch_tags(
 
 Given an Entity type and ID, JSON PATCH the tag. 
 
-Args  entity (T): Entity Type  source: Source entity object  tag_label: TagLabel to add or remove  operation: Patch Operation to add or remove the tag. Returns  Updated Entity 
+**Args:**  
+
+`entity (T)`: Entity Type  
+
+`source`: Source entity object  
+
+`tag_label`: TagLabel to add or remove  
+
+`operation`: Patch Operation to add or remove the tag. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -284,7 +362,11 @@ patch_test_case_definition(
 
 Given a test case and a test case definition JSON PATCH the test case 
 
-Args  test_case: test case object  test_case_definition: test case definition to add 
+**Args:**  
+
+`test_case`: test case object  
+
+`test_case_definition`: test case definition to add 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/patch_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/patch_mixin.md
@@ -265,7 +265,9 @@ Given an Entity type and ID, JSON PATCH the owner. If not owner Entity type and 
 
 `entity_id`: ID of the entity to be patched  
 
-`owner`: Entity Reference of the owner. If None, the owner will be removed  force: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. 
+`owner`: Entity Reference of the owner. If None, the owner will be removed  
+
+`force`: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. 
 
 **Returns:**  
 

--- a/content/v1.8.x/sdk/python/api-reference/patch_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/patch_mixin.md
@@ -77,7 +77,7 @@ Given an Entity type and Source entity and Destination entity, generate a JSON P
 
 **Args:**
 
-`entity (T)`: Entity Type  
+`entity` (T): Entity Type  
 
 `source`: Source payload which is current state of the source in OpenMetadata  
 
@@ -200,7 +200,7 @@ Given an Entity type and ID, JSON PATCH the description.
 
 **Args:**  
 
-`entity (T)`: Entity Type  
+`entity` (T): Entity Type  
 
 `source`: source entity object  
 
@@ -261,7 +261,7 @@ Given an Entity type and ID, JSON PATCH the owner. If not owner Entity type and 
 
 **Args:**  
 
-`entity (T)`: Entity Type of the entity to be patched  
+`entity` (T): Entity Type of the entity to be patched  
 
 `entity_id`: ID of the entity to be patched  
 
@@ -334,7 +334,7 @@ Given an Entity type and ID, JSON PATCH the tag.
 
 **Args:**  
 
-`entity (T)`: Entity Type  
+`entity` (T): Entity Type  
 
 `source`: Source entity object  
 

--- a/content/v1.8.x/sdk/python/api-reference/query_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/query_mixin.md
@@ -45,8 +45,8 @@ Get the queries attached to a table
 
 **Args:**
  
- - <b>`entity_id`</b> (Union[Uuid,str]):  entity id of given entity 
- - <b>`fields`</b> (Optional[List[str]]):  list of fields to be included in response 
+ - `entity_id` (Union[Uuid,str]):  entity id of given entity 
+ - `fields` (Optional[List[str]]):  list of fields to be included in response 
 
 
 
@@ -54,7 +54,7 @@ Get the queries attached to a table
 
 **Returns:**
  
- - <b>`Optional[List[Query]]`</b>:  List of queries 
+ - `Optional[List[Query]]`:  List of queries 
 
 ---
 
@@ -71,7 +71,11 @@ ingest_entity_queries_data(
 
 PUT queries for an entity 
 
-:param entity: Entity to update :param queries: CreateQueryRequest to add 
+**Args:**
+
+`entity`: Entity to update 
+
+`queries`: CreateQueryRequest to add 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/search_index_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/search_index_mixin.md
@@ -39,9 +39,13 @@ ingest_search_index_sample_data(
 ) → Optional[SearchIndexSampleData]
 ```
 
-PUT sample data for a search index 
+PUT sample data for a search index
 
-:param search_index: SearchIndex Entity to update :param sample_data: Data to add 
+**Args:**
+
+`search_index`: SearchIndex Entity to update 
+
+`sample_data`: Data to add 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/service_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/service_mixin.md
@@ -39,9 +39,17 @@ Create a service of type T.
 We need to extract from the WorkflowSource: 
 - name: serviceName 
 - serviceType: Type Enum 
-- connection: (DatabaseConnection, DashboardConnection...) 
+- connection: (DatabaseConnection, DashboardConnection...)
 
-:param entity: Service Type :param config: WorkflowSource :return: Created Service 
+**Args:**
+
+`entity`: Service Type 
+
+`config`: WorkflowSource 
+
+**Returns:**
+
+Created Service 
 
 ---
 
@@ -53,7 +61,17 @@ We need to extract from the WorkflowSource:
 get_create_service_from_source(entity: Type[~T], config: Source) → ~C
 ```
 
-Prepare a CreateService request from source config :param entity: Service Type :param config: WorkflowSource :return: CreateService request 
+Prepare a CreateService request from source config 
+
+**Args:**
+
+`entity`: Service Type 
+
+`config`: WorkflowSource 
+
+**Returns:**
+
+CreateService request 
 
 If the OpenMetadata Connection has storeServiceConnection set to false, we won't pass the connection details when creating the service. 
 
@@ -67,7 +85,17 @@ If the OpenMetadata Connection has storeServiceConnection set to false, we won't
 get_service_or_create(entity: Type[~T], config: Source) → ~T
 ```
 
-Fetches a service by name, or creates it using the WorkflowSource config :param entity: Entity Type to get or create :param config: WorkflowSource :return: Entity Service of T 
+Fetches a service by name, or creates it using the WorkflowSource config 
+
+**Args:**
+
+`entity`: Entity Type to get or create 
+
+`config`: WorkflowSource
+
+**Returns:**
+
+Entity Service of T 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/table_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/table_mixin.md
@@ -48,7 +48,7 @@ Create or update custom metric. If custom metric name matches an existing one th
 
 **Args:**
  
- - <b>`custom_metric`</b> (CreateCustomMetricRequest):  custom metric to be create or updated 
+ - `custom_metric` (CreateCustomMetricRequest):  custom metric to be create or updated 
 
 ---
 
@@ -63,9 +63,17 @@ create_or_update_table_profiler_config(
 ) → Optional[Table]
 ```
 
-Update the profileSample property of a Table, given its FQN. 
+Update the profileSample property of a Table, given its FQN.
 
-:param fqn: Table FQN :param profile_sample: new profile sample to set :return: Updated table 
+**Args:**
+
+`fqn`: Table FQN 
+
+`profile_sample`: new profile sample to set 
+
+**Returns:**
+
+Updated table 
 
 ---
 
@@ -83,13 +91,13 @@ Get the latest profile data for a table
 
 **Args:**
  
- - <b>`fqn`</b> (str):  table fully qualified name 
+ - `fqn` (str):  table fully qualified name 
 
 
 
 **Returns:**
  
- - <b>`Optional[Table]`</b>:  OM table object 
+ - `Optional[Table]`:  OM table object 
 
 ---
 
@@ -114,23 +122,23 @@ Get profile data
 
 **Args:**
  
- - <b>`fqn`</b> (str):  fullyQualifiedName 
- - <b>`start_ts`</b> (int):  start timestamp 
- - <b>`end_ts`</b> (int):  end timestamp 
- - <b>`limit`</b> (int, optional):  limit of record to return. Defaults to 100. 
- - <b>`after`</b> (_type_, optional):  use for API pagination. Defaults to None. profile_type (Union[Type[TableProfile], Type[ColumnProfile]], optional):  Profile type to retrieve. Defaults to TableProfile. 
+ - `fqn` (str):  fullyQualifiedName 
+ - `start_ts` (int):  start timestamp 
+ - `end_ts` (int):  end timestamp 
+ - `limit` (int, optional):  limit of record to return. Defaults to 100. 
+ - `after` (_type_, optional):  use for API pagination. Defaults to None. profile_type (Union[Type[TableProfile], Type[ColumnProfile]], optional):  Profile type to retrieve. Defaults to TableProfile. 
 
 
 
 **Raises:**
  
- - <b>`TypeError`</b>:  if `profile_type` is not TableProfile or ColumnProfile 
+ - `TypeError`:  if `profile_type` is not TableProfile or ColumnProfile 
 
 
 
 **Returns:**
  
- - <b>`EntityList`</b>:  EntityList list object 
+ - `EntityList`:  EntityList list object 
 
 ---
 
@@ -159,9 +167,13 @@ ingest_profile_data(
 ) → Table
 ```
 
-PUT profile data for a table 
+PUT profile data for a table
 
-:param table: Table Entity to update :param table_profile: Profile data to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`table_profile`: Profile data to add 
 
 ---
 
@@ -173,9 +185,13 @@ PUT profile data for a table
 ingest_table_data_model(table: Table, data_model: DataModel) → Table
 ```
 
-PUT data model for a table 
+PUT data model for a table
 
-:param table: Table Entity to update :param data_model: Model to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`data_model`: Model to add 
 
 ---
 
@@ -190,9 +206,13 @@ ingest_table_sample_data(
 ) → Optional[TableData]
 ```
 
-PUT sample data for a table 
+PUT sample data for a table
 
-:param table: Table Entity to update :param sample_data: Data to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`sample_data`: Data to add 
 
 ---
 
@@ -207,9 +227,13 @@ publish_frequently_joined_with(
 ) → None
 ```
 
-POST frequently joined with for a table 
+POST frequently joined with for a table
 
-:param table: Table Entity to update :param table_join_request: Join data to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`table_join_request`: Join data to add 
 
 ---
 
@@ -221,9 +245,13 @@ POST frequently joined with for a table
 publish_table_usage(table: Table, table_usage_request: UsageRequest) → None
 ```
 
-POST usage details for a Table 
+POST usage details for a Table
 
-:param table: Table Entity to update :param table_usage_request: Usage data to add 
+**Args:**
+
+`table`: Table Entity to update 
+
+`table_usage_request`: Usage data to add 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/tests_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/tests_mixin.md
@@ -42,7 +42,7 @@ Add logical test cases to a test suite
 
 **Args:**
  
- - <b>`data`</b> (CreateLogicalTestCases):  logical test cases 
+ - `data` (CreateLogicalTestCases):  logical test cases 
 
 ---
 
@@ -60,14 +60,14 @@ Add test case results to a test case
 
 **Args:**
  
- - <b>`test_results`</b> (TestCaseResult):  test case results to pass to the test case 
- - <b>`test_case_fqn`</b> (str):  test case fqn 
+ - `test_results` (TestCaseResult):  test case results to pass to the test case 
+ - `test_case_fqn` (str):  test case fqn 
 
 
 
 **Returns:**
  
- - <b>`_type_`</b>:  _description_ 
+ - `_type_`:  _description_ 
 
 ---
 
@@ -85,13 +85,13 @@ Create or update an executable test suite
 
 **Args:**
  
- - <b>`data`</b> (CreateTestSuiteRequest):  test suite request 
+ - `data` (CreateTestSuiteRequest):  test suite request 
 
 
 
 **Returns:**
  
- - <b>`TestSuite`</b>:  test suite object 
+ - `TestSuite`:  test suite object 
 
 ---
 
@@ -114,9 +114,9 @@ Delete executable test suite
 
 **Args:**
  
- - <b>`entity_id`</b> (str):  test suite ID 
- - <b>`recursive`</b> (bool, optional):  delete children if true 
- - <b>`hard_delete`</b> (bool, optional):  hard delete if true 
+ - `entity_id` (str):  test suite ID 
+ - `recursive` (bool, optional):  delete children if true 
+ - `hard_delete` (bool, optional):  hard delete if true 
 
 ---
 
@@ -136,7 +136,7 @@ Given an entity fqn, retrieve the link test suite if it exists or create a new o
 
 **Args:**
  
- - <b>`table_fqn`</b> (str):  entity fully qualified name 
+ - `table_fqn` (str):  entity fully qualified name 
 
 
 
@@ -164,17 +164,17 @@ Get or create a test case
 
 **Args:**
  
- - <b>`test_case_fqn`</b> (str):  fully qualified name for the test 
- - <b>`entity_link`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_suite_fqn`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_definition_fqn`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_case_parameter_values`</b> (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_case_fqn` (str):  fully qualified name for the test 
+ - `entity_link` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_suite_fqn` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_definition_fqn` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_case_parameter_values` (Optional[str], optional):  _description_. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`_type_`</b>:  _description_ 
+ - `_type_`:  _description_ 
 
 ---
 
@@ -198,17 +198,17 @@ Get or create a test definition
 
 **Args:**
  
- - <b>`test_definition_fqn`</b> (str):  test definition fully qualified name 
- - <b>`test_definition_description`</b> (Optional[str], optional):  description for the test definition.  Defaults to None. 
- - <b>`entity_type`</b> (Optional[EntityType], optional):  entity type (COLUMN or TABLE). Defaults to None. 
- - <b>`test_platforms`</b> (Optional[List[TestPlatform]], optional):  test platforms. Defaults to None. 
- - <b>`test_case_parameter_definition`</b> (Optional[List[TestCaseParameterDefinition]], optional):  parameters for the  test case definition. Defaults to None. 
+ - `test_definition_fqn` (str):  test definition fully qualified name 
+ - `test_definition_description` (Optional[str], optional):  description for the test definition.  Defaults to None. 
+ - `entity_type` (Optional[EntityType], optional):  entity type (COLUMN or TABLE). Defaults to None. 
+ - `test_platforms` (Optional[List[TestPlatform]], optional):  test platforms. Defaults to None. 
+ - `test_case_parameter_definition` (Optional[List[TestCaseParameterDefinition]], optional):  parameters for the  test case definition. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`TestDefinition`</b>:  a test definition object 
+ - `TestDefinition`:  a test definition object 
 
 ---
 
@@ -229,8 +229,8 @@ Get or create a TestSuite
 
 **Args:**
  
- - <b>`test_suite_name`</b> (str):  test suite name 
- - <b>`test_suite_description`</b> (Optional[str], optional):  test suite description.  Defaults to f"Test Suite created on {datetime.now(timezone.utc).strftime('%Y-%m-%d')}". 
+ - `test_suite_name` (str):  test suite name 
+ - `test_suite_description` (Optional[str], optional):  test suite description.  Defaults to f"Test Suite created on {datetime.now(timezone.utc).strftime('%Y-%m-%d')}". 
 
 
 
@@ -257,9 +257,9 @@ Retrieve list of test cases
 
 **Args:**
  
- - <b>`test_case_fqn`</b> (str):  test_case_fqn 
- - <b>`start_ts`</b> (int):  timestamp 
- - <b>`end_ts`</b> (int):  timestamp 
+ - `test_case_fqn` (str):  test_case_fqn 
+ - `start_ts` (int):  timestamp 
+ - `end_ts` (int):  timestamp 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/topic_mixin.md
+++ b/content/v1.8.x/sdk/python/api-reference/topic_mixin.md
@@ -39,9 +39,13 @@ ingest_topic_sample_data(
 ) → TopicSampleData
 ```
 
-PUT sample data for a topic 
+PUT sample data for a topic
 
-:param topic: Topic Entity to update :param sample_data: Data to add 
+**Args:**
+
+`topic`: Topic Entity to update 
+
+`sample_data`: Data to add 
 
 
 

--- a/content/v1.8.x/sdk/python/api-reference/utils.md
+++ b/content/v1.8.x/sdk/python/api-reference/utils.md
@@ -21,7 +21,15 @@ Helper functions to handle OpenMetadata Entities' properties
 format_name(name: str) → str
 ```
 
-Given a name, replace all special characters by `_` :param name: name to format :return: formatted string 
+Given a name, replace all special characters by `_` 
+
+**Args:**
+
+`name`: name to format 
+
+**Returns:**
+
+formatted string 
 
 
 ---

--- a/content/v1.9.x/sdk/python/api-reference/auth_provider.md
+++ b/content/v1.9.x/sdk/python/api-reference/auth_provider.md
@@ -70,7 +70,7 @@ Create authentication
 
 **Arguments:**
  
- - <b>`config`</b> (ConfigModel):  configuration 
+ - `config` (ConfigModel):  configuration 
 
 **Returns:**
  AuthenticationProvider 

--- a/content/v1.9.x/sdk/python/api-reference/client.md
+++ b/content/v1.9.x/sdk/python/api-reference/client.md
@@ -80,7 +80,10 @@ Return response status code
 [{% image align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /%}](https://github.com/open-metadata/OpenMetadata/tree/main/ingestion/src/metadata/ingestion/ometa/client.py#L89")
 
 ## class `ClientConfig`
-:param raw_data: should we return api response raw or wrap it with  Entity objects. 
+
+**Args:**
+
+`raw_data`: should we return api response raw or wrap it with  Entity objects. 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/client_utils.md
+++ b/content/v1.9.x/sdk/python/api-reference/client_utils.md
@@ -27,13 +27,13 @@ Create an OpenMetadata client
 
 **Args:**
  
- - <b>`metadata_config`</b> (OpenMetadataConnection):  OM connection config 
+ - `metadata_config` (OpenMetadataConnection):  OM connection config 
 
 
 
 **Returns:**
  
- - <b>`OpenMetadata`</b>:  an OM client 
+ - `OpenMetadata`:  an OM client 
 
 
 ---

--- a/content/v1.9.x/sdk/python/api-reference/dashboard_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/dashboard_mixin.md
@@ -41,7 +41,11 @@ publish_dashboard_usage(
 
 POST usage details for a Dashboard 
 
-:param dashboard: Table Entity to update :param dashboard_usage_request: Usage data to add 
+**Args:**
+
+`dashboard`: Table Entity to update 
+
+`dashboard_usage_request`: Usage data to add 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/data_insight_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/data_insight_mixin.md
@@ -40,7 +40,7 @@ Given a ReportData object convert it to a json payload and send a POST request t
 
 **Args:**
  
- - <b>`record`</b> (ReportData):  report data 
+ - `record` (ReportData):  report data 
 
 ---
 
@@ -58,7 +58,7 @@ Given a ReportData object convert it to a json payload and send a POST request t
 
 **Args:**
  
- - <b>`record`</b> (ReportData):  report data 
+ - `record` (ReportData):  report data 
 
 ---
 
@@ -104,7 +104,7 @@ Delete report data for a specific report data type
 
 **Args:**
  
- - <b>`report_data_type`</b> (ReportDataType):  report date type to delete 
+ - `report_data_type` (ReportDataType):  report date type to delete 
 
 ---
 
@@ -125,8 +125,8 @@ Delete report data at a specific date for a specific report data type
 
 **Args:**
  
- - <b>`report_data_type`</b> (ReportDataType):  report date type to delete 
- - <b>`date`</b> (str):  date for which to delete the report data 
+ - `report_data_type` (ReportDataType):  report date type to delete 
+ - `date` (str):  date for which to delete the report data 
 
 ---
 
@@ -147,8 +147,8 @@ Deletes web analytics events before a timestamp
 
 **Args:**
  
- - <b>`event_type`</b> (WebAnalyticEventData):  web analytic event type 
- - <b>`tmsp`</b> (int):  timestamp 
+ - `event_type` (WebAnalyticEventData):  web analytic event type 
+ - `tmsp` (int):  timestamp 
 
 ---
 
@@ -172,17 +172,17 @@ _summary_
 
 **Args:**
  
- - <b>`start_ts`</b> (int):  _description_ 
- - <b>`end_ts`</b> (int):  _description_ 
- - <b>`data_insight_chart_name`</b> (str):  _description_ 
- - <b>`data_report_index`</b> (str):  _description_ 
- - <b>`params`</b> (Optional[dict], optional):  _description_. Defaults to None. 
+ - `start_ts` (int):  _description_ 
+ - `end_ts` (int):  _description_ 
+ - `data_insight_chart_name` (str):  _description_ 
+ - `data_report_index` (str):  _description_ 
+ - `params` (Optional[dict], optional):  _description_. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`DataInsightChartResult`</b>:  _description_ 
+ - `DataInsightChartResult`:  _description_ 
 
 ---
 
@@ -204,9 +204,9 @@ Return dict with a list of report data given a start and end date
 
 **Args:**
  
- - <b>`start_ts`</b> (_type_):  start_timestamp 
- - <b>`end_ts`</b> (_type_):  end timestampe 
- - <b>`report_data_type`</b> (ReportDataType):  report data type 
+ - `start_ts` (_type_):  start_timestamp 
+ - `end_ts` (_type_):  end timestampe 
+ - `report_data_type` (ReportDataType):  report data type 
 
 
 
@@ -229,7 +229,7 @@ Given FQN return KPI results
 
 **Args:**
  
- - <b>`fqn`</b> (str):  fullyQualifiedName 
+ - `fqn` (str):  fullyQualifiedName 
 
 ---
 

--- a/content/v1.9.x/sdk/python/api-reference/es_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/es_mixin.md
@@ -49,9 +49,23 @@ es_search_from_fqn(
 ) → Optional[List[~T]]
 ```
 
-Given a service_name and some filters, search for entities using ES 
+Given a service_name and some filters, search for entities using ES
 
-:param entity_type: Entity to look for :param fqn_search_string: string used to search by FQN. E.g., service.*.schema.table :param from_count: Records to expect :param size: Number of records :param fields: Comma separated list of fields to be returned :return: List of entities 
+**Args:**
+
+`entity_type`: Entity to look for 
+
+`fqn_search_string`: string used to search by FQN. E.g., service.*.schema.table 
+
+`from_count`: Records to expect 
+
+`size`: Number of records 
+
+`fields`: Comma separated list of fields to be returned 
+
+**Returns:**
+
+List of entities 
 
 ---
 

--- a/content/v1.9.x/sdk/python/api-reference/index.md
+++ b/content/v1.9.x/sdk/python/api-reference/index.md
@@ -50,7 +50,7 @@ slug: /sdk/python/api-reference
 - [`auth_provider.OktaAuthenticationProvider`](/sdk/python/api-reference/auth-provider#class-oktaauthenticationprovider): Prepare the Json Web Token for Okta auth
 - [`auth_provider.OpenMetadataAuthenticationProvider`](/sdk/python/api-reference/auth-provider#class-openmetadataauthenticationprovider): OpenMetadata authentication implementation
 - [`client.APIError`](/sdk/python/api-reference/client#class-apierror): Represent API related error.
-- [`client.ClientConfig`](/sdk/python/api-reference/client#class-clientconfig): :param raw_data: should we return api response raw or wrap it with
+- [`client.ClientConfig`](/sdk/python/api-reference/client#class-clientconfig): Returns api response raw or wrap it with Entity objects
 - [`client.REST`](/sdk/python/api-reference/client#class-rest): REST client wrapper to manage requests with
 - [`client.RetryException`](/sdk/python/api-reference/client#class-retryexception): API Client retry exception
 - [`credentials.DATE`](/sdk/python/api-reference/credentials#class-date): date string in the format YYYY-MM-DD

--- a/content/v1.9.x/sdk/python/api-reference/ingestion_pipeline_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/ingestion_pipeline_mixin.md
@@ -41,7 +41,11 @@ create_or_update_pipeline_status(
 
 PUT create or update pipeline status 
 
-:param ingestion_pipeline_fqn: Ingestion Pipeline FQN :param pipeline_status: Pipeline Status data to add 
+**Args:**
+
+`ingestion_pipeline_fqn`: Ingestion Pipeline FQN 
+
+`pipeline_status`: Pipeline Status data to add 
 
 ---
 
@@ -62,8 +66,8 @@ Get ingestion pipeline statues based on name
 
 **Args:**
  
- - <b>`name`</b> (str):  Ingestion Pipeline Name 
- - <b>`fields`</b> (List[str]):  List of all the fields 
+ - `name` (str):  Ingestion Pipeline Name 
+ - `fields` (List[str]):  List of all the fields 
 
 ---
 
@@ -80,7 +84,11 @@ get_pipeline_status(
 
 GET pipeline status 
 
-:param ingestion_pipeline_fqn: Ingestion Pipeline FQN :param pipeline_status_run_id: Pipeline Status run id 
+**Args:**
+
+`ingestion_pipeline_fqn`: Ingestion Pipeline FQN 
+
+`pipeline_status_run_id`: Pipeline Status run id 
 
 ---
 
@@ -102,9 +110,9 @@ Get pipeline status between timestamp
 
 **Args:**
  
- - <b>`ingestion_pipeline_fqn`</b> (str):  pipeline fqn 
- - <b>`start_ts`</b> (int):  start_ts 
- - <b>`end_ts`</b> (int):  end_ts 
+ - `ingestion_pipeline_fqn` (str):  pipeline fqn
+ - `start_ts` (int):  start_ts 
+ - `end_ts` (int):  end_ts 
 
 ---
 
@@ -122,7 +130,7 @@ Run ingestion pipeline workflow
 
 **Args:**
  
- - <b>`ingestion_pipeline_id`</b> (str):  ingestion pipeline uuid 
+ - `ingestion_pipeline_id` (str):  ingestion pipeline uuid 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/lineage_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/lineage_mixin.md
@@ -86,7 +86,17 @@ get_lineage_by_id(
 ) → Optional[Dict[str, Any]]
 ```
 
-Get lineage details for an entity `id` :param entity: Type of the entity :param entity_id: Entity ID :param up_depth: Upstream depth of lineage (default=1, min=0, max=3)" :param down_depth: Downstream depth of lineage (default=1, min=0, max=3) 
+Get lineage details for an entity `id` 
+
+**Args:**
+
+`entity`: Type of the entity 
+
+`entity_id`: Entity ID 
+
+`up_depth`: Upstream depth of lineage (default=1, min=0, max=3)" 
+
+`down_depth`: Downstream depth of lineage (default=1, min=0, max=3) 
 
 ---
 
@@ -103,7 +113,17 @@ get_lineage_by_name(
 ) → Optional[Dict[str, Any]]
 ```
 
-Get lineage details for an entity `id` :param entity: Type of the entity :param fqn: Entity FQN :param up_depth: Upstream depth of lineage (default=1, min=0, max=3)" :param down_depth: Downstream depth of lineage (default=1, min=0, max=3) 
+Get lineage details for an entity `id` 
+
+**Args:**
+
+`entity`: Type of the entity 
+
+`fqn`: Entity FQN 
+
+`up_depth`: Upstream depth of lineage (default=1, min=0, max=3)" 
+
+`down_depth`: Downstream depth of lineage (default=1, min=0, max=3) 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/mlmodel_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/mlmodel_mixin.md
@@ -39,7 +39,17 @@ add_mlmodel_lineage(
 ) → Dict[str, Any]
 ```
 
-Iterates over MlModel's Feature Sources and add the lineage information. :param model: MlModel containing EntityReferences :param description: Lineage description :return: List of added lineage information 
+Iterates over MlModel's Feature Sources and add the lineage information. 
+
+**Args:**
+
+`model`: MlModel containing EntityReferences 
+
+`description`: Lineage description 
+
+**Returns:**
+
+List of added lineage information 
 
 ---
 
@@ -58,7 +68,21 @@ get_mlmodel_sklearn(
 
 Get an MlModel Entity instance from a scikit-learn model. 
 
-Sklearn estimators all extend BaseEstimator. :param name: MlModel name :param model: sklearn estimator :param description: MlModel description :param service_name: Service name to use when creating sklearn service :return: OpenMetadata CreateMlModelRequest Entity 
+Sklearn estimators all extend BaseEstimator. 
+
+**Args:**
+
+`name`: MlModel name 
+
+`model`: sklearn estimator 
+
+`description`: MlModel description 
+
+`service_name`: Service name to use when creating sklearn service 
+
+**Returns:**
+
+OpenMetadata CreateMlModelRequest Entity 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.9.x/sdk/python/api-reference/ometa_api.md
@@ -255,7 +255,21 @@ list_all_entities(
 ) → Iterable[~T]
 ```
 
-Utility method that paginates over all EntityLists to return a generator to fetch entities :param entity: Entity Type, such as Table :param fields: Extra fields to return :param limit: Number of entities in each pagination :param params: Extra parameters, e.g., {"service": "serviceName"} to filter :return: Generator that will be yielding all Entities 
+Utility method that paginates over all EntityLists to return a generator to fetch entities.
+
+**Parameters**:
+
+- `entity`: Entity Type, such as Table
+
+- `fields`: Extra fields to return
+
+- `limit`: Number of entities in each pagination
+
+- `params`: Extra parameters, e.g., {"service": "serviceName"} to filter
+
+**Returns**:
+
+Generator that will be yielding all Entities 
 
 ---
 

--- a/content/v1.9.x/sdk/python/api-reference/ometa_api.md
+++ b/content/v1.9.x/sdk/python/api-reference/ometa_api.md
@@ -201,7 +201,17 @@ Inversely, import the Entity type based on the create Entity class
 get_entity_reference(entity: Type[~T], fqn: str) → Optional[EntityReference]
 ```
 
-Helper method to obtain an EntityReference from a FQN and the Entity class. :param entity: Entity Class :param fqn: Entity instance FQN :return: EntityReference or None 
+Helper method to obtain an EntityReference from a FQN and the Entity class. 
+
+**Args:**
+
+`entity`: Entity Class 
+
+`fqn`: Entity instance FQN 
+
+**Returns:**
+
+EntityReference or None 
 
 ---
 

--- a/content/v1.9.x/sdk/python/api-reference/patch_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/patch_mixin.md
@@ -77,7 +77,7 @@ Given an Entity type and Source entity and Destination entity, generate a JSON P
 
 **Args:**  
 
-`entity (T)`: Entity Type  
+`entity` (T): Entity Type  
 
 `source`: Source payload which is current state of the source in OpenMetadata  
 
@@ -198,7 +198,7 @@ Given an Entity type and ID, JSON PATCH the description.
 
 **Args:**  
 
-`entity (T)`: Entity Type  
+`entity` (T): Entity Type  
 
 `source`: source entity object  
 
@@ -257,7 +257,7 @@ Given an Entity type and ID, JSON PATCH the owner. If not owner Entity type and 
 
 **Args:**  
 
-`entity (T)`: Entity Type of the entity to be patched  
+`entity` (T): Entity Type of the entity to be patched  
 
 `entity_id`: ID of the entity to be patched  
 
@@ -330,7 +330,7 @@ Given an Entity type and ID, JSON PATCH the tag.
 
 **Args:**  
 
-`entity (T)`: Entity Type  
+`entity` (T): Entity Type  
 
 `source`: Source entity object  
 

--- a/content/v1.9.x/sdk/python/api-reference/patch_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/patch_mixin.md
@@ -126,7 +126,9 @@ Given an Table , Column FQN, JSON PATCH the description of the column
 
 `column_fqn`: FQN of the column to update  
 
-`description`: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
+`description`: new description to add  
+
+`force`: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
 
 **Returns:** 
 
@@ -202,7 +204,9 @@ Given an Entity type and ID, JSON PATCH the description.
 
 `source`: source entity object  
 
-`description`: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
+`description`: new description to add  
+
+`force`: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
 
 **Returns:**  
 
@@ -261,7 +265,9 @@ Given an Entity type and ID, JSON PATCH the owner. If not owner Entity type and 
 
 `entity_id`: ID of the entity to be patched  
 
-`owner`: Entity Reference of the owner. If None, the owner will be removed  force: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. 
+`owner`: Entity Reference of the owner. If None, the owner will be removed  
+
+`force`: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. 
 
 **Returns:**  
 

--- a/content/v1.9.x/sdk/python/api-reference/patch_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/patch_mixin.md
@@ -75,9 +75,17 @@ patch(entity: Type[~T], source: ~T, destination: ~T) → Optional[~T]
 
 Given an Entity type and Source entity and Destination entity, generate a JSON Patch and apply it. 
 
-Args  entity (T): Entity Type  source: Source payload which is current state of the source in OpenMetadata  destination: payload with changes applied to the source. 
+**Args:**  
 
-Returns  Updated Entity 
+`entity (T)`: Entity Type  
+
+`source`: Source payload which is current state of the source in OpenMetadata  
+
+`destination`: payload with changes applied to the source. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -112,7 +120,17 @@ patch_column_description(
 
 Given an Table , Column FQN, JSON PATCH the description of the column 
 
-Args  src_table: origin Table object  column_fqn: FQN of the column to update  description: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`src_table`: origin Table object  
+
+`column_fqn`: FQN of the column to update  
+
+`description`: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
+
+**Returns:** 
+
+Updated Entity 
 
 ---
 
@@ -147,7 +165,19 @@ patch_column_tags(
 
 Given an Entity ID, JSON PATCH the tag of the column 
 
-Args  entity_id: ID  tag_label: TagLabel to add or remove  column_name: column to update  operation: Patch Operation to add or remove Returns  Updated Entity 
+**Args:**  
+
+`entity_id`: ID  
+
+`tag_label`: TagLabel to add or remove  
+
+`column_name`: column to update  
+
+`operation`: Patch Operation to add or remove 
+
+**Returns:** 
+
+Updated Entity 
 
 ---
 
@@ -166,7 +196,17 @@ patch_description(
 
 Given an Entity type and ID, JSON PATCH the description. 
 
-Args  entity (T): Entity Type  source: source entity object  description: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`entity (T)`: Entity Type  
+
+`source`: source entity object  
+
+`description`: new description to add  force: if True, we will patch any existing description. Otherwise, we will maintain  the existing data. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -190,9 +230,13 @@ Patch domain data for an Entity
 patch_life_cycle(entity: BaseModel, life_cycle: LifeCycle) → Optional[BaseModel]
 ```
 
-Patch life cycle data for a entity 
+Patch life cycle data for a entity
 
-:param entity: Entity to update the life cycle for :param life_cycle_data: Life Cycle data to add 
+**Args:**
+
+`entity`: Entity to update the life cycle for 
+
+`life_cycle_data`: Life Cycle data to add 
 
 ---
 
@@ -211,7 +255,17 @@ patch_owner(
 
 Given an Entity type and ID, JSON PATCH the owner. If not owner Entity type and not owner ID are provided, the owner is removed. 
 
-Args  entity (T): Entity Type of the entity to be patched  entity_id: ID of the entity to be patched  owner: Entity Reference of the owner. If None, the owner will be removed  force: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. Returns  Updated Entity 
+**Args:**  
+
+`entity (T)`: Entity Type of the entity to be patched  
+
+`entity_id`: ID of the entity to be patched  
+
+`owner`: Entity Reference of the owner. If None, the owner will be removed  force: if True, we will patch any existing owner. Otherwise, we will maintain  the existing data. 
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -228,9 +282,17 @@ patch_table_constraints(
 
 Given an Entity ID, JSON PATCH the table constraints of table 
 
-Args  source_table: Origin table  description: new description to add  table_constraints: table constraints to add 
+**Args:**  
 
-Returns  Updated Entity 
+`source_table`: Origin table  
+
+`description`: new description to add  
+
+`table_constraints`: table constraints to add
+
+**Returns:**  
+
+Updated Entity 
 
 ---
 
@@ -266,7 +328,19 @@ patch_tags(
 
 Given an Entity type and ID, JSON PATCH the tag. 
 
-Args  entity (T): Entity Type  source: Source entity object  tag_label: TagLabel to add or remove  operation: Patch Operation to add or remove the tag. Returns  Updated Entity 
+**Args:**  
+
+`entity (T)`: Entity Type  
+
+`source`: Source entity object  
+
+`tag_label`: TagLabel to add or remove  
+
+`operation`: Patch Operation to add or remove the tag. 
+
+**Returns:**
+
+Updated Entity 
 
 ---
 
@@ -284,7 +358,11 @@ patch_test_case_definition(
 
 Given a test case and a test case definition JSON PATCH the test case 
 
-Args  test_case: test case object  test_case_definition: test case definition to add 
+**Args:**  
+
+`test_case`: test case object  
+
+`test_case_definition`: test case definition to add 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/query_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/query_mixin.md
@@ -48,10 +48,6 @@ Get the queries attached to a table
  - `entity_id` (Union[Uuid,str]):  entity id of given entity 
  - `fields` (Optional[List[str]]):  list of fields to be included in response 
 
-
-
-
-
 **Returns:**
  
  - `Optional[List[Query]]`:  List of queries 

--- a/content/v1.9.x/sdk/python/api-reference/query_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/query_mixin.md
@@ -45,8 +45,8 @@ Get the queries attached to a table
 
 **Args:**
  
- - <b>`entity_id`</b> (Union[Uuid,str]):  entity id of given entity 
- - <b>`fields`</b> (Optional[List[str]]):  list of fields to be included in response 
+ - `entity_id` (Union[Uuid,str]):  entity id of given entity 
+ - `fields` (Optional[List[str]]):  list of fields to be included in response 
 
 
 
@@ -54,7 +54,7 @@ Get the queries attached to a table
 
 **Returns:**
  
- - <b>`Optional[List[Query]]`</b>:  List of queries 
+ - `Optional[List[Query]]`:  List of queries 
 
 ---
 
@@ -71,7 +71,11 @@ ingest_entity_queries_data(
 
 PUT queries for an entity 
 
-:param entity: Entity to update :param queries: CreateQueryRequest to add 
+**Args:**
+
+`entity`: Entity to update 
+
+`queries`: CreateQueryRequest to add 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/search_index_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/search_index_mixin.md
@@ -39,9 +39,13 @@ ingest_search_index_sample_data(
 ) → Optional[SearchIndexSampleData]
 ```
 
-PUT sample data for a search index 
+PUT sample data for a search index
 
-:param search_index: SearchIndex Entity to update :param sample_data: Data to add 
+**Args:**
+
+`search_index`: SearchIndex Entity to update 
+
+`sample_data`: Data to add 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/service_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/service_mixin.md
@@ -39,9 +39,17 @@ Create a service of type T.
 We need to extract from the WorkflowSource: 
 - name: serviceName 
 - serviceType: Type Enum 
-- connection: (DatabaseConnection, DashboardConnection...) 
+- connection: (DatabaseConnection, DashboardConnection...)
 
-:param entity: Service Type :param config: WorkflowSource :return: Created Service 
+**Args:**
+
+`entity`: Service Type 
+
+`config`: WorkflowSource 
+
+**Returns:**
+
+Created Service 
 
 ---
 
@@ -53,7 +61,17 @@ We need to extract from the WorkflowSource:
 get_create_service_from_source(entity: Type[~T], config: Source) → ~C
 ```
 
-Prepare a CreateService request from source config :param entity: Service Type :param config: WorkflowSource :return: CreateService request 
+Prepare a CreateService request from source config 
+
+**Args:**
+
+`entity`: Service Type 
+
+`config`: WorkflowSource 
+
+**Returns:**
+
+CreateService request 
 
 If the OpenMetadata Connection has storeServiceConnection set to false, we won't pass the connection details when creating the service. 
 
@@ -67,7 +85,16 @@ If the OpenMetadata Connection has storeServiceConnection set to false, we won't
 get_service_or_create(entity: Type[~T], config: Source) → ~T
 ```
 
-Fetches a service by name, or creates it using the WorkflowSource config :param entity: Entity Type to get or create :param config: WorkflowSource :return: Entity Service of T 
+Fetches a service by name, or creates it using the WorkflowSource config 
+
+**Args:**
+
+`entity`: Entity Type to get or create
+
+`config`: WorkflowSource 
+
+**Returns:**
+Entity Service of T 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/table_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/table_mixin.md
@@ -48,7 +48,7 @@ Create or update custom metric. If custom metric name matches an existing one th
 
 **Args:**
  
- - <b>`custom_metric`</b> (CreateCustomMetricRequest):  custom metric to be create or updated 
+ - `custom_metric` (CreateCustomMetricRequest):  custom metric to be create or updated 
 
 ---
 
@@ -91,13 +91,13 @@ Get the latest profile data for a table
 
 **Args:**
  
- - <b>`fqn`</b> (str):  table fully qualified name 
+ - `fqn` (str):  table fully qualified name 
 
 
 
 **Returns:**
  
- - <b>`Optional[Table]`</b>:  OM table object 
+ - `Optional[Table]`:  OM table object 
 
 ---
 
@@ -122,23 +122,23 @@ Get profile data
 
 **Args:**
  
- - <b>`fqn`</b> (str):  fullyQualifiedName 
- - <b>`start_ts`</b> (int):  start timestamp 
- - <b>`end_ts`</b> (int):  end timestamp 
- - <b>`limit`</b> (int, optional):  limit of record to return. Defaults to 100. 
- - <b>`after`</b> (_type_, optional):  use for API pagination. Defaults to None. profile_type (Union[Type[TableProfile], Type[ColumnProfile]], optional):  Profile type to retrieve. Defaults to TableProfile. 
+ - `fqn` (str):  fullyQualifiedName 
+ - `start_ts` (int):  start timestamp 
+ - `end_ts` (int):  end timestamp 
+ - `limit` (int, optional):  limit of record to return. Defaults to 100. 
+ - `after` (_type_, optional):  use for API pagination. Defaults to None. profile_type (Union[Type[TableProfile], Type[ColumnProfile]], optional):  Profile type to retrieve. Defaults to TableProfile. 
 
 
 
 **Raises:**
  
- - <b>`TypeError`</b>:  if `profile_type` is not TableProfile or ColumnProfile 
+ - `TypeError`:  if `profile_type` is not TableProfile or ColumnProfile 
 
 
 
 **Returns:**
  
- - <b>`EntityList`</b>:  EntityList list object 
+ - `EntityList`:  EntityList list object 
 
 ---
 

--- a/content/v1.9.x/sdk/python/api-reference/table_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/table_mixin.md
@@ -63,9 +63,17 @@ create_or_update_table_profiler_config(
 ) → Optional[Table]
 ```
 
-Update the profileSample property of a Table, given its FQN. 
+Update the profileSample property of a Table, given its FQN.
 
-:param fqn: Table FQN :param profile_sample: new profile sample to set :return: Updated table 
+**Parameters:**
+
+`fqn`: Table FQN 
+
+`profile_sample`: new profile sample to set 
+
+**Returns:**
+
+Updated table 
 
 ---
 
@@ -161,7 +169,11 @@ ingest_profile_data(
 
 PUT profile data for a table 
 
-:param table: Table Entity to update :param table_profile: Profile data to add 
+**Parameters:**
+
+`table`: Table Entity to update 
+
+`table_profile`: Profile data to add 
 
 ---
 
@@ -173,9 +185,13 @@ PUT profile data for a table
 ingest_table_data_model(table: Table, data_model: DataModel) → Table
 ```
 
-PUT data model for a table 
+PUT data model for a table
 
-:param table: Table Entity to update :param data_model: Model to add 
+**Parameters:**
+
+`table`: Table Entity to update 
+
+`data_model`: Model to add 
 
 ---
 
@@ -190,9 +206,13 @@ ingest_table_sample_data(
 ) → Optional[TableData]
 ```
 
-PUT sample data for a table 
+PUT sample data for a table
 
-:param table: Table Entity to update :param sample_data: Data to add 
+**Parameters:**
+
+`table`: Table Entity to update 
+
+`sample_data`: Data to add 
 
 ---
 
@@ -207,9 +227,13 @@ publish_frequently_joined_with(
 ) → None
 ```
 
-POST frequently joined with for a table 
+POST frequently joined with for a table
 
-:param table: Table Entity to update :param table_join_request: Join data to add 
+**Parameters:**
+
+`table`: Table Entity to update 
+
+`table_join_request`: Join data to add 
 
 ---
 
@@ -223,7 +247,11 @@ publish_table_usage(table: Table, table_usage_request: UsageRequest) → None
 
 POST usage details for a Table 
 
-:param table: Table Entity to update :param table_usage_request: Usage data to add 
+**Parameters:**
+
+`table`: Table Entity to update 
+
+`table_usage_request`: Usage data to add 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/table_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/table_mixin.md
@@ -65,7 +65,7 @@ create_or_update_table_profiler_config(
 
 Update the profileSample property of a Table, given its FQN.
 
-**Parameters:**
+**Args:**
 
 `fqn`: Table FQN 
 
@@ -169,7 +169,7 @@ ingest_profile_data(
 
 PUT profile data for a table 
 
-**Parameters:**
+**Args:**
 
 `table`: Table Entity to update 
 
@@ -187,7 +187,7 @@ ingest_table_data_model(table: Table, data_model: DataModel) → Table
 
 PUT data model for a table
 
-**Parameters:**
+**Args:**
 
 `table`: Table Entity to update 
 
@@ -208,7 +208,7 @@ ingest_table_sample_data(
 
 PUT sample data for a table
 
-**Parameters:**
+**Args:**
 
 `table`: Table Entity to update 
 
@@ -229,7 +229,7 @@ publish_frequently_joined_with(
 
 POST frequently joined with for a table
 
-**Parameters:**
+**Args:**
 
 `table`: Table Entity to update 
 
@@ -247,7 +247,7 @@ publish_table_usage(table: Table, table_usage_request: UsageRequest) → None
 
 POST usage details for a Table 
 
-**Parameters:**
+**Args:**
 
 `table`: Table Entity to update 
 

--- a/content/v1.9.x/sdk/python/api-reference/tests_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/tests_mixin.md
@@ -42,7 +42,7 @@ Add logical test cases to a test suite
 
 **Args:**
  
- - <b>`data`</b> (CreateLogicalTestCases):  logical test cases 
+ - `data` (CreateLogicalTestCases):  logical test cases 
 
 ---
 
@@ -60,14 +60,14 @@ Add test case results to a test case
 
 **Args:**
  
- - <b>`test_results`</b> (TestCaseResult):  test case results to pass to the test case 
- - <b>`test_case_fqn`</b> (str):  test case fqn 
+ - `test_results` (TestCaseResult):  test case results to pass to the test case 
+ - `test_case_fqn` (str):  test case fqn 
 
 
 
 **Returns:**
  
- - <b>`_type_`</b>:  _description_ 
+ - `_type_`:  _description_ 
 
 ---
 
@@ -85,13 +85,13 @@ Create or update an executable test suite
 
 **Args:**
  
- - <b>`data`</b> (CreateTestSuiteRequest):  test suite request 
+ - `data` (CreateTestSuiteRequest):  test suite request 
 
 
 
 **Returns:**
  
- - <b>`TestSuite`</b>:  test suite object 
+ - `TestSuite`:  test suite object 
 
 ---
 
@@ -114,9 +114,9 @@ Delete executable test suite
 
 **Args:**
  
- - <b>`entity_id`</b> (str):  test suite ID 
- - <b>`recursive`</b> (bool, optional):  delete children if true 
- - <b>`hard_delete`</b> (bool, optional):  hard delete if true 
+ - `entity_id` (str):  test suite ID 
+ - `recursive` (bool, optional):  delete children if true 
+ - `hard_delete` (bool, optional):  hard delete if true 
 
 ---
 
@@ -136,7 +136,7 @@ Given an entity fqn, retrieve the link test suite if it exists or create a new o
 
 **Args:**
  
- - <b>`table_fqn`</b> (str):  entity fully qualified name 
+ - `table_fqn` (str):  entity fully qualified name 
 
 
 
@@ -164,17 +164,17 @@ Get or create a test case
 
 **Args:**
  
- - <b>`test_case_fqn`</b> (str):  fully qualified name for the test 
- - <b>`entity_link`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_suite_fqn`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_definition_fqn`</b> (Optional[str], optional):  _description_. Defaults to None. 
- - <b>`test_case_parameter_values`</b> (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_case_fqn` (str):  fully qualified name for the test 
+ - `entity_link` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_suite_fqn` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_definition_fqn` (Optional[str], optional):  _description_. Defaults to None. 
+ - `test_case_parameter_values` (Optional[str], optional):  _description_. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`_type_`</b>:  _description_ 
+ - `_type_`:  _description_ 
 
 ---
 
@@ -198,17 +198,17 @@ Get or create a test definition
 
 **Args:**
  
- - <b>`test_definition_fqn`</b> (str):  test definition fully qualified name 
- - <b>`test_definition_description`</b> (Optional[str], optional):  description for the test definition.  Defaults to None. 
- - <b>`entity_type`</b> (Optional[EntityType], optional):  entity type (COLUMN or TABLE). Defaults to None. 
- - <b>`test_platforms`</b> (Optional[List[TestPlatform]], optional):  test platforms. Defaults to None. 
- - <b>`test_case_parameter_definition`</b> (Optional[List[TestCaseParameterDefinition]], optional):  parameters for the  test case definition. Defaults to None. 
+ - `test_definition_fqn` (str):  test definition fully qualified name 
+ - `test_definition_description` (Optional[str], optional):  description for the test definition.  Defaults to None. 
+ - `entity_type` (Optional[EntityType], optional):  entity type (COLUMN or TABLE). Defaults to None. 
+ - `test_platforms` (Optional[List[TestPlatform]], optional):  test platforms. Defaults to None. 
+ - `test_case_parameter_definition` (Optional[List[TestCaseParameterDefinition]], optional):  parameters for the  test case definition. Defaults to None. 
 
 
 
 **Returns:**
  
- - <b>`TestDefinition`</b>:  a test definition object 
+ - `TestDefinition`:  a test definition object 
 
 ---
 
@@ -229,8 +229,8 @@ Get or create a TestSuite
 
 **Args:**
  
- - <b>`test_suite_name`</b> (str):  test suite name 
- - <b>`test_suite_description`</b> (Optional[str], optional):  test suite description.  Defaults to f"Test Suite created on {datetime.now(timezone.utc).strftime('%Y-%m-%d')}". 
+ - `test_suite_name` (str):  test suite name 
+ - `test_suite_description` (Optional[str], optional):  test suite description.  Defaults to f"Test Suite created on {datetime.now(timezone.utc).strftime('%Y-%m-%d')}". 
 
 
 
@@ -257,9 +257,9 @@ Retrieve list of test cases
 
 **Args:**
  
- - <b>`test_case_fqn`</b> (str):  test_case_fqn 
- - <b>`start_ts`</b> (int):  timestamp 
- - <b>`end_ts`</b> (int):  timestamp 
+ - `test_case_fqn` (str):  test_case_fqn 
+ - `start_ts` (int):  timestamp 
+ - `end_ts` (int):  timestamp 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/topic_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/topic_mixin.md
@@ -41,7 +41,11 @@ ingest_topic_sample_data(
 
 PUT sample data for a topic 
 
-:param topic: Topic Entity to update :param sample_data: Data to add 
+**Parameters:**
+
+`topic`: Topic Entity to update 
+
+`sample_data`: Data to add 
 
 
 

--- a/content/v1.9.x/sdk/python/api-reference/topic_mixin.md
+++ b/content/v1.9.x/sdk/python/api-reference/topic_mixin.md
@@ -41,7 +41,7 @@ ingest_topic_sample_data(
 
 PUT sample data for a topic 
 
-**Parameters:**
+**Args:**
 
 `topic`: Topic Entity to update 
 

--- a/content/v1.9.x/sdk/python/api-reference/utils.md
+++ b/content/v1.9.x/sdk/python/api-reference/utils.md
@@ -21,7 +21,15 @@ Helper functions to handle OpenMetadata Entities' properties
 format_name(name: str) → str
 ```
 
-Given a name, replace all special characters by `_` :param name: name to format :return: formatted string 
+Given a name, replace all special characters by `_` 
+
+**Parameters:**
+
+`name`: name to format 
+
+**Returns:**
+
+formatted string 
 
 
 ---

--- a/content/v1.9.x/sdk/python/api-reference/utils.md
+++ b/content/v1.9.x/sdk/python/api-reference/utils.md
@@ -23,7 +23,7 @@ format_name(name: str) → str
 
 Given a name, replace all special characters by `_` 
 
-**Parameters:**
+**Args:**
 
 `name`: name to format 
 


### PR DESCRIPTION
## 📘 Summary
This PR edits the Openmetadata docs to be rendered properly in the .md file

## 🔍 Related Issue / Ticket
Fixes open-metadata/OpenMetadata#22823


## ✨ Changes
Changed the `:params` content in the .md docs file for the v1.10.x, v1.8.x, and v1.9.x versions so that they are rendered properly. The `:params` can only work well in a .rst file. And not a .md file.

I also removed the <b> and </b> tags in the .md files as these only works properly in html files

## 🧪 Testing
- [x] Locally built the docs with `yarn dev`
- [x] Verified formatting

## 📸 Screenshots

P.S. It is important to note that there were several files edited in this PR. The screenshot below only displays changes in one of the files.

### Before Code Changes

<img width="764" height="347" alt="Non-Rendered screenshot" src="https://github.com/user-attachments/assets/2928cc89-376f-479e-8508-0a944cc30a3d" />


### After Code Changes

<img width="773" height="365" alt="After Param Rendering" src="https://github.com/user-attachments/assets/46493c42-3c86-49f8-8bbc-11b93849932f" />

