### PR TITLE
Improve documentation for running OpenMetadata with Postgres

### DIFF
--- a/content/partials/v1.8/developers/contribute/build-code-and-run-tests/postgres-compose-instructions.md
+++ b/content/partials/v1.8/developers/contribute/build-code-and-run-tests/postgres-compose-instructions.md
@@ -1,0 +1,10 @@
+{%note%}
+If you're following this tutorial using the Postgres compose file (`docker/development/docker-compose-postgres.yml`), make sure you set the following environment variables to override the default OpenMetadata settings.
+
+```
+DB_DRIVER_CLASS=org.postgresql.Driver
+DB_PORT=5432
+DB_SCHEME=postgresql
+SEARCH_TYPE=opensearch
+```
+{%/note%}

--- a/content/v1.10.x-SNAPSHOT/developers/contribute/build-code-and-run-tests/openmetadata-server.md
+++ b/content/v1.10.x-SNAPSHOT/developers/contribute/build-code-and-run-tests/openmetadata-server.md
@@ -20,6 +20,8 @@ docker compose -f docker/development/docker-compose.yml up mysql elasticsearch -
 docker compose -f docker/development/docker-compose-postgres.yml up postgresql opensearch --build -d
 ```
 
+{% partial file="/v1.8/developers/contribute/build-code-and-run-tests/postgres-compose-instructions.md" /%}
+
 ## Building
 The following commands must be run from the top-level directory.
 
@@ -43,7 +45,7 @@ openmetadata-dist/target/open-metadata-<version>.pom
 openmetadata-dist/target/open-metadata-<version>.tar.gz
 ```
 
-## Bootstrap MySQL
+## Bootstrap Database
 
 Extract the distribution tar.gz file created on the previous step and run the following command
 
@@ -112,7 +114,7 @@ We also need to set the folder ‘generated-resources’ in some module’s targ
 
 Now run/debug the application.
 
-## Load Sample Data into MySQL
+## Load Sample Data into the database
 
 With the OpenMetadata service up and running, run the following commands from the top-level directory
 

--- a/content/v1.8.x/developers/contribute/build-code-and-run-tests/openmetadata-server.md
+++ b/content/v1.8.x/developers/contribute/build-code-and-run-tests/openmetadata-server.md
@@ -20,6 +20,8 @@ docker compose -f docker/development/docker-compose.yml up mysql elasticsearch -
 docker compose -f docker/development/docker-compose-postgres.yml up postgresql opensearch --build -d
 ```
 
+{% partial file="/v1.8/developers/contribute/build-code-and-run-tests/postgres-compose-instructions.md" /%}
+
 ## Building
 The following commands must be run from the top-level directory.
 
@@ -43,7 +45,7 @@ openmetadata-dist/target/open-metadata-<version>.pom
 openmetadata-dist/target/open-metadata-<version>.tar.gz
 ```
 
-## Bootstrap MySQL
+## Bootstrap Database
 
 Extract the distribution tar.gz file created on the previous step and run the following command
 
@@ -112,7 +114,7 @@ We also need to set the folder ‘generated-resources’ in some module’s targ
 
 Now run/debug the application.
 
-## Load Sample Data into MySQL
+## Load Sample Data into the database
 
 With the OpenMetadata service up and running, run the following commands from the top-level directory
 

--- a/content/v1.9.x/developers/contribute/build-code-and-run-tests/openmetadata-server.md
+++ b/content/v1.9.x/developers/contribute/build-code-and-run-tests/openmetadata-server.md
@@ -20,6 +20,8 @@ docker compose -f docker/development/docker-compose.yml up mysql elasticsearch -
 docker compose -f docker/development/docker-compose-postgres.yml up postgresql opensearch --build -d
 ```
 
+{% partial file="/v1.8/developers/contribute/build-code-and-run-tests/postgres-compose-instructions.md" /%}
+
 ## Building
 The following commands must be run from the top-level directory.
 
@@ -27,7 +29,9 @@ The following commands must be run from the top-level directory.
 mvn clean install
 ```
 
-If you wish to skip the unit tests you can do this by adding `-DskipTests` to the command line.
+{%note%}
+This will run all tests, which can take up to an hour. Use `-DskipTests` to skip unit tests if you're only interested in running the server.
+{%/note%}
 
 ## Create a distribution (packaging)
 You can create a distribution as follows.
@@ -43,7 +47,7 @@ openmetadata-dist/target/open-metadata-<version>.pom
 openmetadata-dist/target/open-metadata-<version>.tar.gz
 ```
 
-## Bootstrap MySQL
+## Bootstrap Database
 
 Extract the distribution tar.gz file created on the previous step and run the following command
 
@@ -112,7 +116,7 @@ We also need to set the folder ‘generated-resources’ in some module’s targ
 
 Now run/debug the application.
 
-## Load Sample Data into MySQL
+## Load Sample Data into the database
 
 With the OpenMetadata service up and running, run the following commands from the top-level directory
 


### PR DESCRIPTION
The docs to [run OpenMetadata server](https://docs.open-metadata.org/latest/developers/contribute/build-code-and-run-tests/openmetadata-server) mention two different setups, one with MySQL and ElasticSearch (`docker/development/docker-compose.yml`) and another with Postgres and OpenSearch (`docker/development/docker-compose-postgres.yml`), but the instructions below only focus on the first option.

This change instructs developers to set the right environment variables needed to change the server configuration for Postgres and OpenSearch.