### PR TITLE
Edit api connector yaml file

### DIFF
--- a/content/v1.10.x-SNAPSHOT/connectors/api/rest/yaml.md
+++ b/content/v1.10.x-SNAPSHOT/connectors/api/rest/yaml.md
@@ -64,7 +64,7 @@ source:
   serviceName: openapi_rest
   serviceConnection:
     config:
-      type: ApiMetadata
+      type: Rest
 ```
 ```yaml {% srNumber=1 %}
       openAPISchemaURL: https://docs.open-metadata.org/swagger.json

--- a/content/v1.8.x/connectors/api/rest/yaml.md
+++ b/content/v1.8.x/connectors/api/rest/yaml.md
@@ -64,7 +64,7 @@ source:
   serviceName: openapi_rest
   serviceConnection:
     config:
-      type: ApiMetadata
+      type: Rest
 ```
 ```yaml {% srNumber=1 %}
       openAPISchemaURL: https://docs.open-metadata.org/swagger.json

--- a/content/v1.9.x/connectors/api/rest/yaml.md
+++ b/content/v1.9.x/connectors/api/rest/yaml.md
@@ -64,7 +64,7 @@ source:
   serviceName: openapi_rest
   serviceConnection:
     config:
-      type: ApiMetadata
+      type: Rest
 ```
 ```yaml {% srNumber=1 %}
       openAPISchemaURL: https://docs.open-metadata.org/swagger.json


### PR DESCRIPTION
## 📘 Summary
This PR edits the ConfigType in the external connector API yaml file

## 🔍 Related Issue / Ticket
Fixes open-metadata/OpenMetadata#22126


## ✨ Changes
Changed the config type parameter in the external connector api yaml file for the v1.10.x, v1.8.x, and v1.9.x versions from ApiMetadata to Rest. This prevents the error shown when the metadata ingest command is run.

## 🧪 Testing
- [x] Locally built the docs with `yarn dev`
- [x] Verified formatting

## 📸 Screenshots

### Before Code Changes

<img width="938" height="452" alt="wrong metadata ingestion" src="https://github.com/user-attachments/assets/397994c8-bea2-482d-a2d1-bf79c72d189e" />


### After Code Changes

<img width="682" height="118" alt="correct metadata api ingestion" src="https://github.com/user-attachments/assets/593ac1f5-699b-483c-a5e3-230f457c1f86" />