### PR TITLE
Fix canonical URL to not have undefined

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -39,7 +39,7 @@ export default function MyApp({ Component, pageProps }: AppProps<SlugProps>) {
     ? DESCRIPTION
     : pageDescription;
 
-  const canonicalUrl = `${HOST_NAME}/${router.query.version}/${slug?.join('/') || ''}`;
+  const canonicalUrl = `${HOST_NAME}/${router.query.version ?? '/latest'}/${slug?.join('/') || ''}`;
 
   const [storedCookie, setStoredCookie] = useState<string | null>(null);
 


### PR DESCRIPTION
Previously, when accessing https://docs.open-metadata.org/, for few millisecond, the canonical is setting to https://docs.open-metadata.org/undefined, which is not good for SEO. To overcome this undefined, updated the canonical to have /latest if no version is used.