### PR TITLE
docs: add patch_entity tool reference to MCP docs

### DIFF
--- a/content/v1.10.x-SNAPSHOT/how-to-guides/mcp/reference.md
+++ b/content/v1.10.x-SNAPSHOT/how-to-guides/mcp/reference.md
@@ -324,3 +324,70 @@ This document provides detailed examples and usage patterns for all available {%
 | `fqn` | string | Yes | Fully qualified name of the entity |
 | `upstream_depth` | integer | Yes | Depth for upstream entities (default: 5) |
 | `downstream_depth` | integer | Yes | Depth for ...
+
+---
+
+### 6. patch_entity
+
+**Description**: Patch an entity using a JSONPatch operation. Typically used to update attributes like description, owner, or tags. Before applying a patch, the entity should be validated by retrieving it first and then constructing the appropriate patch.
+
+#### Parameters
+
+| Parameter    | Type   | Required | Description                                                    |
+| ------------ | ------ | -------- | -------------------------------------------------------------- |
+| `entityType` | string | Yes      | Type of entity to patch (e.g., table, dashboard, glossaryTerm) |
+| `entityFqn`  | string | Yes      | Fully qualified name of the entity                             |
+| `patch`      | string | Yes      | JSONPatch in string format, defining the changes               |
+
+#### Example – Update a Table Description
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "tools/call",
+  "params": {
+    "name": "patch_entity",
+    "arguments": {
+      "entityType": "table",
+      "entityFqn": "mysql_prod.ecommerce.public.customer_orders",
+      "patch": "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"Updated description: Customer order transactions with enhanced detail.\" }]"
+    }
+  }
+}
+```
+
+#### Example – Add a Tag to a Table
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "tools/call",
+  "params": {
+    "name": "patch_entity",
+    "arguments": {
+      "entityType": "table",
+      "entityFqn": "mysql_prod.ecommerce.public.customer_orders",
+      "patch": "[{ \"op\": \"add\", \"path\": \"/tags/-\", \"value\": \"Customer-Data\" }]"
+    }
+  }
+}
+```
+
+**Sample Response**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "✅ Successfully patched entity: **mysql_prod.ecommerce.public.customer_orders**\n\n**Applied Patch**:\n- Operation: replace\n- Path: /description\n- Value: Updated description: Customer order transactions with enhanced detail\n\n[View Updated Entity in OpenMetadata](https://your-om.com/table/mysql_prod.ecommerce.public.customer_orders)"
+      }
+    ]
+  }
+}
+```

--- a/content/v1.8.x/how-to-guides/mcp/reference.md
+++ b/content/v1.8.x/how-to-guides/mcp/reference.md
@@ -324,3 +324,70 @@ This document provides detailed examples and usage patterns for all available {%
 | `fqn` | string | Yes | Fully qualified name of the entity |
 | `upstream_depth` | integer | Yes | Depth for upstream entities (default: 5) |
 | `downstream_depth` | integer | Yes | Depth for ...
+
+---
+
+### 6. patch_entity
+
+**Description**: Patch an entity using a JSONPatch operation. Typically used to update attributes like description, owner, or tags. Before applying a patch, the entity should be validated by retrieving it first and then constructing the appropriate patch.
+
+#### Parameters
+
+| Parameter    | Type   | Required | Description                                                    |
+| ------------ | ------ | -------- | -------------------------------------------------------------- |
+| `entityType` | string | Yes      | Type of entity to patch (e.g., table, dashboard, glossaryTerm) |
+| `entityFqn`  | string | Yes      | Fully qualified name of the entity                             |
+| `patch`      | string | Yes      | JSONPatch in string format, defining the changes               |
+
+#### Example – Update a Table Description
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "tools/call",
+  "params": {
+    "name": "patch_entity",
+    "arguments": {
+      "entityType": "table",
+      "entityFqn": "mysql_prod.ecommerce.public.customer_orders",
+      "patch": "[{ \"op\": \"replace\", \"path\": \"/description\", \"value\": \"Updated description: Customer order transactions with enhanced detail.\" }]"
+    }
+  }
+}
+```
+
+#### Example – Add a Tag to a Table
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "tools/call",
+  "params": {
+    "name": "patch_entity",
+    "arguments": {
+      "entityType": "table",
+      "entityFqn": "mysql_prod.ecommerce.public.customer_orders",
+      "patch": "[{ \"op\": \"add\", \"path\": \"/tags/-\", \"value\": \"Customer-Data\" }]"
+    }
+  }
+}
+```
+
+**Sample Response**:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "✅ Successfully patched entity: **mysql_prod.ecommerce.public.customer_orders**\n\n**Applied Patch**:\n- Operation: replace\n- Path: /description\n- Value: Updated description: Customer order transactions with enhanced detail\n\n[View Updated Entity in OpenMetadata](https://your-om.com/table/mysql_prod.ecommerce.public.customer_orders)"
+      }
+    ]
+  }
+}
+```

--- a/content/v1.9.x/how-to-guides/mcp/reference.md
+++ b/content/v1.9.x/how-to-guides/mcp/reference.md
@@ -391,5 +391,3 @@ This document provides detailed examples and usage patterns for all available {%
   }
 }
 ```
-
----


### PR DESCRIPTION
### 📖 Summary

This PR updates the **OpenMetadata MCP Tools Reference** documentation by adding support and examples for the **`patch_entity`** tool for versions - 1.8.X/1.9.X/1.10.X

---

### ✅ Changes Introduced

* Added **section 6: `patch_entity`** in MCP tools reference.
* Documented parameters (`entityType`, `entityFqn`, `patch`) with clear descriptions.
* Provided **usage examples**:

  * Updating entity descriptions.
  * Adding tags to entities.
* Included a **sample response block** for better clarity.
* Ensured consistency with existing tool documentation (format, tone, JSON-RPC examples).

---

### 📌 Why This Change?

* Extends MCP docs with **update functionality** (not just search, retrieval, creation).
* Enables contributors and users to quickly understand how to perform partial updates to entities using JSONPatch.
* Aligns with OpenMetadata’s commitment to **self-service governance and metadata management**.

---

### 🔍 Testing / Validation

* Verified formatting consistency with other MCP tool entries.
* Ensured examples follow valid JSONPatch operations.
* Cross-checked parameter naming with API specs.

---

### 🎯 Next Steps (Optional Enhancements)

* Add more examples covering ownership updates and glossary term edits.
* Link to JSONPatch specification for contributors unfamiliar with the syntax.

---

### 📝 PR Metadata

* **Type**: Documentation
* **Scope**: MCP Tools Reference (`/how-to-guides/mcp/reference`)
* **Impact**: Documentation only (no code changes)

---